### PR TITLE
Set 'optable' as the 'id' and 'name' attributes of fpd.user.data

### DIFF
--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -48,8 +48,8 @@ function PrebidUserDataFromCache(config: OptableConfig): PrebidUserData {
 
     if (segments.length > 0) {
       result.push({
-        id: key,
-        name: key,
+        id: "optable",
+        name: "optable",
         segment: segments,
       });
     }


### PR DESCRIPTION
We hardcode the string "optable" as the value of both the `fpd.user.data.id` and `fpd.user.data.name` attributes in Prebid.js when configuring `fpd.user.data` on behalf of an integrating publisher. This identifies the "provider" of the data as "optable" universally, to all bid adapters, regardless of the originating sandbox/customer -- the provider is always "optable".

That said, since the `key` attribute/name and the associated `value` attribute/name are generated by the customer sandbox for each activated and matching audience, and since `value` is highly probably globally unique, and since customers are unlikely to be combining audience-spaces from multiple sandboxes in a single destination bidder/ad server account, we will hopefully be OK with this approach.
