### PR TITLE
Move to proposed edge targeting v2 response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,21 +166,19 @@ type ProfileTraits = {
 
 ### Targeting API
 
-To get the targeting key values associated by the configured DCN with the user's browser in real-time, you can call the targeting API as follows:
+To get the targeting information associated by the configured DCN with the user's browser in real-time, you can call the targeting API as follows:
 
 ```js
 sdk
   .targeting()
-  .then((keyvalues) => {
-    // Iterate over all the key values entries and print them
-    for (const [key, values] of Object.entries(keyvalues)) {
-      console.log(`Targeting KV: ${key} = ${values.join(",")}`);
-    }
+  .then((response) => {
+    console.log(`Audience targeting: ${targeting.audience}`)
+    console.log(`User targeting: ${targeting.user}`)
   })
   .catch((err) => console.warn(`Targeting API Error: ${err.message}`));
 ```
 
-On success, the resulting key values are typically sent as part of a subsequent ad call. Therefore we recommend that you either call targeting() before each ad call, or in parallel periodically, caching the resulting key values which you then provide in ad calls.
+On success, the resulting targeting data is typically sent as part of a subsequent ad call. Therefore we recommend that you either call targeting() before each ad call, or in parallel periodically, caching the resulting targeting data which you then provide in ad calls.
 
 #### Caching Targeting Data
 
@@ -189,9 +187,8 @@ The `targeting` API will automatically cache resulting key value data in client 
 ```{javascript
 const cachedTargetingData = sdk.targetingFromCache();
 if (cachedTargetingData) {
-  for (const [key, values] of Object.entries(cachedTargetingData)) {
-    console.log(`Targeting KV: ${key} = ${values.join(",")}`);
-  }
+  console.log(`Audience targeting: ${targeting.audience}`)
+  console.log(`User targeting: ${targeting.user}`)
 }
 ```
 
@@ -271,7 +268,7 @@ The following shows an example of how to safely initialize the SDK and dispatch 
 
 ## Integrating GAM360
 
-The Optable Web SDK can fetch targeting keyvalue data from a DCN and send it to a [Google Ad Manager 360](https://admanager.google.com/home/) ad server account for real-time targeting. It's also capable of intercepting advertising events from the [Google Publisher Tag](https://developers.google.com/doubleclick-gpt/guides/get-started) and logging them to a DCN via the **witness API**.
+The Optable Web SDK can fetch targeting data from a DCN and map it to be sent to [Google Ad Manager 360](https://admanager.google.com/home/) ad server account for real-time targeting. It's also capable of intercepting advertising events from the [Google Publisher Tag](https://developers.google.com/doubleclick-gpt/guides/get-started) and logging them to a DCN via the **witness API**.
 
 ### Targeting key values
 
@@ -333,10 +330,8 @@ It's suggested to load the GAM banner view with an ad even when the call to your
   // so that GAM ads are always loaded.
   optable.cmd.push(function () {
     optable.instance
-      .targeting()
-      .then(function (result) {
-        loadGAM(result);
-      })
+      .targetingKeyValues()
+      .then(loadGAM)
       .catch((err) => {
         loadGAM();
       });
@@ -352,7 +347,7 @@ Note the use of `googletag.pubads().disableInitialLoad()` in the above example. 
 
 ### Targeting key values from local cache
 
-It's also possible to avoid disabling of the initial ad load by using the SDK's `targetingFromCache()` method instead as in the following example:
+It's also possible to avoid disabling of the initial ad load by using the SDK's `targetingKeyValuesFromCache()` method instead as in the following example:
 
 ```html
 <!-- Optable SDK async load: -->
@@ -379,7 +374,7 @@ It's also possible to avoid disabling of the initial ad load by using the SDK's 
 
     // Attempt to load Optable targeting key values from local cache, then load GAM ads:
     optable.cmd.push(function () {
-      const tdata = optable.instance.targetingFromCache();
+      const tdata = optable.instance.targetingKeyValuesFromCache();
       for (const [key, values] of Object.entries(tdata)) {
         googletag.pubads().setTargeting(key, values);
       }
@@ -536,7 +531,7 @@ For a working demo showing a `pbjs` and GAM integrated together, see the [demo p
 
 ### Custom key values
 
-For bidder adapters that do not support SDA, but that do support targeting private marketplace deals to key values, you can use a samilar approach to the [Google Ad Manager integration with key values from local cache](#targeting-key-values-from-local-cache). For example, for the IX bidder adapter and [IX bidder-specific FPD](https://docs.prebid.org/dev-docs/bidders/ix.html#ix-bidder-specific-fpd), you can encode the targeting key values as shown below:
+For bidder adapters that do not support SDA, but that do support targeting private marketplace deals to key values, you can use a similar approach to the [Google Ad Manager integration with key values from local cache](#targeting-key-values-from-local-cache). For example, for the IX bidder adapter and [IX bidder-specific FPD](https://docs.prebid.org/dev-docs/bidders/ix.html#ix-bidder-specific-fpd), you can encode the targeting key values as shown below:
 
 ```html
 <script>
@@ -544,7 +539,7 @@ For bidder adapters that do not support SDA, but that do support targeting priva
   // prior to pbjs.requestBids():
   pbjs.que.push(function () {
     optable.cmd.push(function () {
-      const tdata = optable.instance.targetingFromCache();
+      const tdata = optable.instance.targetingKeyValuesFromCache();
       var fpd = {};
 
       /*

--- a/demos/npm/src/identifyAndTargeting.js
+++ b/demos/npm/src/identifyAndTargeting.js
@@ -29,7 +29,7 @@ sdk.identify(emailID, ppid)
 // DCN that are activated AND include one (or more) of the current user's registered identifiers.
 // See https://github.com/Optable/optable-web-sdk#targeting-api for more info.
 sdk
-  .targeting()
+  .targetingKeyValues()
   .then((keyvalues) => {
     for (const [key, values] of Object.entries(keyvalues)) {
       console.log(`Targeting KV: ${key} = ${values.join(",")}`);

--- a/demos/vanilla/nocookies/targeting/gam360-cached.html
+++ b/demos/vanilla/nocookies/targeting/gam360-cached.html
@@ -71,7 +71,7 @@
 
         // Setup page-level GAM targeting from any cached targeting data and load ads as usual:
         optable.cmd.push(function () {
-          const tdata = optable.instance.targetingFromCache();
+          const tdata = optable.instance.targetingKeyValuesFromCache();
 
           if (tdata) {
             for (const [key, values] of Object.entries(tdata)) {

--- a/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
@@ -71,7 +71,7 @@
 
         // Setup page-level GAM targeting from any cached targeting data and load ads as usual:
         optable.cmd.push(function () {
-          const tdata = optable.instance.targetingFromCache();
+          const tdata = optable.instance.targetingKeyValuesFromCache();
 
           if (tdata) {
             for (const [key, values] of Object.entries(tdata)) {

--- a/demos/vanilla/nocookies/targeting/gam360.html
+++ b/demos/vanilla/nocookies/targeting/gam360.html
@@ -52,13 +52,11 @@
       // Try to fetch targeting data from sandbox and pass it to GAM:
       optable.cmd.push(function () {
         optable.instance
-          .targeting()
-          .then(function (result) {
-            loadGAM(result);
-          })
+          .targetingKeyValues()
+          .then(loadGAM)
           .catch((err) => {
             console.log("[OptableSDK] targeting() exception: " + err.message);
-            loadGAM();
+            loadGAM()
           });
       });
     </script>
@@ -116,7 +114,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, the call to the <code>targeting</code> API happens first and, on success or error, banner
+            In this example, the call to the <code>targetingKeyValues()</code> API happens first and, on success or error, banner
             ads are loaded from Optable's demo GAM account via <code>googletag.pubads().refresh()</code>. In order to
             prevent ads loading until the asynchronous <code>targeting</code> call is done, we start by disabling
             automatic ads loading with <code>googletag.pubads().disableInitialLoad()</code>.

--- a/demos/vanilla/nocookies/targeting/gam360.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360.html.tpl
@@ -52,13 +52,11 @@
       // Try to fetch targeting data from sandbox and pass it to GAM:
       optable.cmd.push(function () {
         optable.instance
-          .targeting()
-          .then(function (result) {
-            loadGAM(result);
-          })
+          .targetingKeyValues()
+          .then(loadGAM)
           .catch((err) => {
             console.log("[OptableSDK] targeting() exception: " + err.message);
-            loadGAM();
+            loadGAM()
           });
       });
     </script>
@@ -116,7 +114,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, the call to the <code>targeting</code> API happens first and, on success or error, banner
+            In this example, the call to the <code>targetingKeyValues()</code> API happens first and, on success or error, banner
             ads are loaded from Optable's demo GAM account via <code>googletag.pubads().refresh()</code>. In order to
             prevent ads loading until the asynchronous <code>targeting</code> call is done, we start by disabling
             automatic ads loading with <code>googletag.pubads().disableInitialLoad()</code>.

--- a/demos/vanilla/nocookies/targeting/prebid.html
+++ b/demos/vanilla/nocookies/targeting/prebid.html
@@ -136,7 +136,7 @@
 
           // Setup page-level GAM targeting from any cached targeting data, and load GAM ads:
           optable.cmd.push(function () {
-            const tdata = optable.instance.targetingFromCache();
+            const tdata = optable.instance.targetingKeyValuesFromCache();
 
             if (tdata) {
               for (const [key, values] of Object.entries(tdata)) {
@@ -240,7 +240,7 @@
             we also pass matching active cohorts to GAM.
           </p>
           <p>
-            In this example, we use the <code>prebidUserDataFromCache</code> API to retrieve any targeting data from browser
+            In this example, we use the <code>prebidUserDataFromCache()</code> API to retrieve any targeting data from browser
             LocalStorage, in order to pass it to Prebid.js via <a href="https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy">seller defined audiences</a>. We also call the SDK <code>targeting</code> API
             which will fetch the latest targeting data from our DCN and cache it locally for later use. Since these
             two events happen asynchronously, it's possible that the targeting data passed to GAM is slightly outdated.

--- a/demos/vanilla/nocookies/targeting/prebid.html.tpl
+++ b/demos/vanilla/nocookies/targeting/prebid.html.tpl
@@ -136,7 +136,7 @@
 
           // Setup page-level GAM targeting from any cached targeting data, and load GAM ads:
           optable.cmd.push(function () {
-            const tdata = optable.instance.targetingFromCache();
+            const tdata = optable.instance.targetingKeyValuesFromCache();
 
             if (tdata) {
               for (const [key, values] of Object.entries(tdata)) {
@@ -240,7 +240,7 @@
             we also pass matching active cohorts to GAM.
           </p>
           <p>
-            In this example, we use the <code>prebidUserDataFromCache</code> API to retrieve any targeting data from browser
+            In this example, we use the <code>prebidUserDataFromCache()</code> API to retrieve any targeting data from browser
             LocalStorage, in order to pass it to Prebid.js via <a href="https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy">seller defined audiences</a>. We also call the SDK <code>targeting</code> API
             which will fetch the latest targeting data from our DCN and cache it locally for later use. Since these
             two events happen asynchronously, it's possible that the targeting data passed to GAM is slightly outdated.

--- a/demos/vanilla/targeting/gam360-cached.html
+++ b/demos/vanilla/targeting/gam360-cached.html
@@ -70,10 +70,10 @@
 
         // Setup page-level GAM targeting from any cached targeting data and load ads as usual:
         optable.cmd.push(function () {
-          const tdata = optable.instance.targetingFromCache();
+          const gamTargeting = optable.instance.targetingKeyValuesFromCache();
 
-          if (tdata) {
-            for (const [key, values] of Object.entries(tdata)) {
+          if (gamTargeting) {
+            for (const [key, values] of Object.entries(gamTargeting)) {
               googletag.pubads().setTargeting(key, values);
               console.log("[OptableSDK] googletag.pubads().setTargeting(" + key + ", [" + values + "])");
             }
@@ -107,7 +107,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, we use the <code>targetingFromCache()</code> API to retrieve any targeting data from
+            In this example, we use the <code>targetingKeyValuesFromCache()</code> API to retrieve any targeting data from
             browser LocalStorage, in order to pass it to GPT via <code>googletag.pubads().setTargeting()</code>. We also
             call the SDK <code>targeting</code> API which will fetch the latest targeting data from our DCN and
             cache it locally for later use. Since these two events happen asynchronously, it's possible that the

--- a/demos/vanilla/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/targeting/gam360-cached.html.tpl
@@ -70,10 +70,10 @@
 
         // Setup page-level GAM targeting from any cached targeting data and load ads as usual:
         optable.cmd.push(function () {
-          const tdata = optable.instance.targetingFromCache();
+          const gamTargeting = optable.instance.targetingKeyValuesFromCache();
 
-          if (tdata) {
-            for (const [key, values] of Object.entries(tdata)) {
+          if (gamTargeting) {
+            for (const [key, values] of Object.entries(gamTargeting)) {
               googletag.pubads().setTargeting(key, values);
               console.log("[OptableSDK] googletag.pubads().setTargeting(" + key + ", [" + values + "])");
             }
@@ -107,7 +107,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, we use the <code>targetingFromCache()</code> API to retrieve any targeting data from
+            In this example, we use the <code>targetingKeyValuesFromCache()</code> API to retrieve any targeting data from
             browser LocalStorage, in order to pass it to GPT via <code>googletag.pubads().setTargeting()</code>. We also
             call the SDK <code>targeting</code> API which will fetch the latest targeting data from our DCN and
             cache it locally for later use. Since these two events happen asynchronously, it's possible that the

--- a/demos/vanilla/targeting/gam360.html
+++ b/demos/vanilla/targeting/gam360.html
@@ -51,13 +51,11 @@
       // Try to fetch targeting data from DCN and pass it to GAM:
       optable.cmd.push(function () {
         optable.instance
-          .targeting()
-          .then(function (result) {
-            loadGAM(result);
-          })
+          .targetingKeyValues()
+          .then(loadGAM)
           .catch((err) => {
             console.log("[OptableSDK] targeting() exception: " + err.message);
-            loadGAM();
+            loadGAM()
           });
       });
     </script>
@@ -115,7 +113,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, the call to the <code>targeting</code> API happens first and, on success or error, banner
+            In this example, the call to the <code>targetingKeyValues()</code> API happens first and, on success or error, banner
             ads are loaded from Optable's demo GAM account via <code>googletag.pubads().refresh()</code>. In order to
             prevent ads loading until the asynchronous <code>targeting</code> call is done, we start by disabling
             automatic ads loading with <code>googletag.pubads().disableInitialLoad()</code>.

--- a/demos/vanilla/targeting/gam360.html.tpl
+++ b/demos/vanilla/targeting/gam360.html.tpl
@@ -51,13 +51,11 @@
       // Try to fetch targeting data from DCN and pass it to GAM:
       optable.cmd.push(function () {
         optable.instance
-          .targeting()
-          .then(function (result) {
-            loadGAM(result);
-          })
+          .targetingKeyValues()
+          .then(loadGAM)
           .catch((err) => {
             console.log("[OptableSDK] targeting() exception: " + err.message);
-            loadGAM();
+            loadGAM()
           });
       });
     </script>
@@ -115,7 +113,7 @@
             ad targeting.
           </p>
           <p>
-            In this example, the call to the <code>targeting</code> API happens first and, on success or error, banner
+            In this example, the call to the <code>targetingKeyValues()</code> API happens first and, on success or error, banner
             ads are loaded from Optable's demo GAM account via <code>googletag.pubads().refresh()</code>. In order to
             prevent ads loading until the asynchronous <code>targeting</code> call is done, we start by disabling
             automatic ads loading with <code>googletag.pubads().disableInitialLoad()</code>.

--- a/demos/vanilla/targeting/prebid.html
+++ b/demos/vanilla/targeting/prebid.html
@@ -135,7 +135,7 @@
 
           // Setup page-level GAM targeting from any cached targeting data, and load GAM ads:
           optable.cmd.push(function () {
-            const tdata = optable.instance.targetingFromCache();
+            const tdata = optable.instance.targetingKeyValuesFromCache();
 
             if (tdata) {
               for (const [key, values] of Object.entries(tdata)) {
@@ -163,7 +163,6 @@
             });
 
             console.log("[OptableSDK] pbjs.setConfig(ortb2.user.data)");
-            console.log(pbdata);
           }
 
           pbjs.setConfig({
@@ -239,7 +238,7 @@
             we also pass matching active cohorts to GAM.
           </p>
           <p>
-            In this example, we use the <code>prebidUserDataFromCache</code> API to retrieve any targeting data from browser
+            In this example, we use the <code>prebidUserDataFromCache()</code> API to retrieve any targeting data from browser
             LocalStorage, in order to pass it to Prebid.js via <a href="https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy">seller defined audiences</a>. We also call the SDK <code>targeting</code> API
             which will fetch the latest targeting data from our DCN and cache it locally for later use. Since these
             two events happen asynchronously, it's possible that the targeting data passed to Prebid is slightly outdated.

--- a/demos/vanilla/targeting/prebid.html.tpl
+++ b/demos/vanilla/targeting/prebid.html.tpl
@@ -135,7 +135,7 @@
 
           // Setup page-level GAM targeting from any cached targeting data, and load GAM ads:
           optable.cmd.push(function () {
-            const tdata = optable.instance.targetingFromCache();
+            const tdata = optable.instance.targetingKeyValuesFromCache();
 
             if (tdata) {
               for (const [key, values] of Object.entries(tdata)) {
@@ -163,7 +163,6 @@
             });
 
             console.log("[OptableSDK] pbjs.setConfig(ortb2.user.data)");
-            console.log(pbdata);
           }
 
           pbjs.setConfig({
@@ -239,7 +238,7 @@
             we also pass matching active cohorts to GAM.
           </p>
           <p>
-            In this example, we use the <code>prebidUserDataFromCache</code> API to retrieve any targeting data from browser
+            In this example, we use the <code>prebidUserDataFromCache()</code> API to retrieve any targeting data from browser
             LocalStorage, in order to pass it to Prebid.js via <a href="https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy">seller defined audiences</a>. We also call the SDK <code>targeting</code> API
             which will fetch the latest targeting data from our DCN and cache it locally for later use. Since these
             two events happen asynchronously, it's possible that the targeting data passed to Prebid is slightly outdated.

--- a/lib/core/storage.test.js
+++ b/lib/core/storage.test.js
@@ -1,0 +1,45 @@
+import LocalStorage from './storage'
+import crypto from "crypto";
+
+function randomConfig() {
+  const randomHex = crypto.randomBytes(8).toString("hex");
+  return { host: `host-${randomHex}`, site: `site-${randomHex}`}
+}
+
+describe("LocalStorage", () => {
+  test("allows to store and retrieve a passport", () => {
+    const store = new LocalStorage(randomConfig())
+    expect(store.getPassport()).toBeNull()
+    store.setPassport("abc")
+    expect(store.getPassport()).toEqual("abc")
+    store.clearPassport()
+    expect(store.getPassport()).toBeNull()
+  })
+
+  test("allows to store and retrieve targeting", () => {
+    const store = new LocalStorage(randomConfig())
+    expect(store.getTargeting()).toBeNull()
+    store.setTargeting({ user: [], audience: [] })
+    expect(store.getTargeting()).toEqual({ user: [], audience: [] })
+    store.clearPassport()
+    expect(store.getPassport()).toBeNull()
+  })
+
+  test("auto fixes v1 targeting as v2 base on audience key presence", () => {
+    const store = new LocalStorage(randomConfig())
+    window.localStorage.setItem(store.targetingV1Key, JSON.stringify({ k1: ["v1"], k2: ["v2"] }))
+
+    expect(store.getTargeting()).toEqual({
+      user: [],
+      audience: [
+        { provider: "optable.co", keyspace: "k1", ids: [{id: "v1"}], rtb_segtax: 5001},
+        { provider: "optable.co", keyspace: "k2", ids: [{id: "v2"}], rtb_segtax: 5001},
+      ]
+    })
+
+    store.setTargeting({ audience: [] })
+    expect(store.getTargeting()).toEqual({
+      audience: []
+    })
+  })
+})

--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -36,7 +36,7 @@ class LocalStorage {
 
     const audiences = Object.entries(parsed).map(([keyspace, values]) => {
       return {
-        provider: "optable.co" as const,
+        provider: "optable.co",
         keyspace,
         // 5001 is Optable Private Member Defined Audiences
         // See: https://github.com/InteractiveAdvertisingBureau/openrtb/pull/81

--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -1,5 +1,5 @@
 import type { OptableConfig } from "../config";
-import type { TargetingKeyValues } from "../edge/targeting";
+import type { TargetingResponse } from "../edge/targeting";
 
 function toBinary(str: string): string {
   const codeUnits = new Uint16Array(str.length);
@@ -11,21 +11,52 @@ function toBinary(str: string): string {
 
 class LocalStorage {
   private passportKey: string;
+  private targetingV1Key: string;
   private targetingKey: string;
 
   constructor(private Config: OptableConfig) {
     const sfx = btoa(toBinary(`${this.Config.host}/${this.Config.site}`));
+    // Legacy targeting key
+    this.targetingV1Key = "OPTABLE_TGT_" + sfx;
+
     this.passportKey = "OPTABLE_PASS_" + sfx;
-    this.targetingKey = "OPTABLE_TGT_" + sfx;
+    this.targetingKey = "OPTABLE_V2_TGT_" + sfx;
   }
 
   getPassport(): string | null {
     return window.localStorage.getItem(this.passportKey);
   }
 
-  getTargeting(): TargetingKeyValues | null {
-    const kvs = window.localStorage.getItem(this.targetingKey);
-    return kvs ? (JSON.parse(kvs) as TargetingKeyValues) : null;
+  getV1Targeting(): TargetingResponse | null {
+    const raw = window.localStorage.getItem(this.targetingV1Key);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (!parsed) {
+      return null
+    }
+
+    const audiences = Object.entries(parsed).map(([keyspace, values]) => {
+      return {
+        provider: "optable.co" as const,
+        keyspace,
+        // 5001 is Optable Private Member Defined Audiences
+        // See: https://github.com/InteractiveAdvertisingBureau/openrtb/pull/81
+        //
+        // Starting v2 this is returned in the targeting payload directly
+        rtb_segtax: 5001,
+        ids: [].concat(...[values as any]).map((id: any) => ({id: String(id)})),
+      }
+    })
+
+    return {
+      user: [],
+      audience: audiences,
+    }
+  }
+
+  getTargeting(): TargetingResponse | null {
+    const raw = window.localStorage.getItem(this.targetingKey);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed ? parsed : this.getV1Targeting()
   }
 
   setPassport(passport: string) {
@@ -34,9 +65,9 @@ class LocalStorage {
     }
   }
 
-  setTargeting(keyvalues: TargetingKeyValues) {
-    if (keyvalues) {
-      window.localStorage.setItem(this.targetingKey, JSON.stringify(keyvalues));
+  setTargeting(targeting: TargetingResponse) {
+    if (targeting) {
+      window.localStorage.setItem(this.targetingKey, JSON.stringify(targeting));
     }
   }
 

--- a/lib/edge/targeting.test.js
+++ b/lib/edge/targeting.test.js
@@ -1,0 +1,48 @@
+import { PrebidUserData, TargetingKeyValues } from "./targeting";
+
+describe("PrebidUserData", () => {
+  test("returns empty array on empty input", () => {
+    expect(PrebidUserData(null)).toEqual([])
+    expect(PrebidUserData({})).toEqual([])
+  })
+
+  test("returns for each targeting audiences a user segments compatible with ortb2.user.data", () => {
+    const targeting = {
+      audience: [
+        { ids: [{ id: "a"}, {id: "b"}, {id: "c"}], provider: "optable.co", rtb_segtax: 123 }
+      ],
+      user: [
+        { provider: "uidapi.com", ids: [{id: "d"}] }
+      ]
+    };
+
+    expect(PrebidUserData(targeting)).toEqual(
+      [{name: "optable.co", segment: [{ id: "a"}, {id: "b"}, {id: "c"}], ext: {segtax: 123}}]
+    )
+  })
+})
+
+describe("TargetingKeyValues", () => {
+  test("returns empty object on empty input", () => {
+    expect(TargetingKeyValues(null)).toEqual({})
+    expect(TargetingKeyValues({})).toEqual({})
+  })
+
+  test("returns key values based on keyspace presence", () => {
+    const targeting = {
+      audience: [
+        { ids: [{ id: "a"}, {id: "b"}, {id: "c"}], provider: "optable.co", keyspace: "k1" },
+        { ids: [{ id: "d"}, {id: "e"}, {id: "f"}], provider: "optable.co", keyspace: "k1" },
+        { ids: [{ id: "g"}, {id: "h"}, {id: "i"}], provider: "optable.co", keyspace: "k2" },
+        { ids: [{ id: "j"}, {id: "k"}, {id: "l"}], provider: "optable.co" },
+      ],
+      user: [
+        {provider: "uidapi.com", ids: [{id: "d"}]},
+      ],
+    };
+    expect(TargetingKeyValues(targeting)).toEqual({
+      "k1": ["a", "b", "c", "d", "e", "f"],
+      "k2": ["g", "h", "i"],
+    })
+  })
+})

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -2,12 +2,32 @@ import type { OptableConfig } from "../config";
 import { fetch } from "../core/network";
 import { LocalStorage } from "../core/storage";
 
-type TargetingKeyValues = {
-  [key: string]: string[];
+type AudienceProvider = "optable.co"
+type UserProvider = "optable.co" | "uidapi.com"
+
+type Identifier = {
+  id: string;
 };
 
-async function Targeting(config: OptableConfig): Promise<TargetingKeyValues> {
-  const response: TargetingKeyValues = await fetch("/targeting", config, {
+type AudienceIdentifiers = {
+  ids: Identifier[];
+  provider: AudienceProvider;
+  rtb_segtax: number; // taxonomy identifier for RTB UserSegments
+  keyspace?: string;   // GAM targeting key for optable.co audience provider
+}
+
+type UserIdentifiers = {
+  ids: Identifier[];
+  provider: UserProvider;
+}
+
+type TargetingResponse = {
+  audience?: AudienceIdentifiers[];
+  user?: UserIdentifiers[];
+};
+
+async function Targeting(config: OptableConfig): Promise<TargetingResponse> {
+  const response: TargetingResponse = await fetch("/v2/targeting", config, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -22,7 +42,7 @@ async function Targeting(config: OptableConfig): Promise<TargetingKeyValues> {
   return response;
 }
 
-function TargetingFromCache(config: OptableConfig): TargetingKeyValues | null {
+function TargetingFromCache(config: OptableConfig): TargetingResponse | null {
   const ls = new LocalStorage(config);
   return ls.getTargeting();
 }
@@ -32,7 +52,7 @@ function TargetingClearCache(config: OptableConfig) {
   ls.clearTargeting();
 }
 
-type PrebidUserSegment = { id: string };
+type PrebidUserSegment = Identifier
 type PrebidSegtax = { segtax: number };
 type PrebidUserSegmentProvider = { name: string; ext: PrebidSegtax; segment: PrebidUserSegment[] };
 type PrebidUserData = PrebidUserSegmentProvider[];
@@ -49,25 +69,28 @@ type PrebidUserData = PrebidUserSegmentProvider[];
  * https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy
  * https://iabtechlab.com/wp-content/uploads/2021/03/IABTechLab_Taxonomy_and_Data_Transparency_Standards_to_Support_Seller-defined_Audience_and_Context_Signaling_2021-03.pdf
  */
-function PrebidUserDataFromCache(config: OptableConfig): PrebidUserData {
-  const tdata = TargetingFromCache(config);
-  const result = [];
+function PrebidUserData(tdata: TargetingResponse | null): PrebidUserData {
+  return (tdata?.audience ?? []).map((identifiers) => ({
+    name: identifiers.provider,
+    segment: identifiers.ids,
+    ext: { segtax: identifiers.rtb_segtax },
+  }))
+}
 
-  for (const [_, values] of Object.entries(tdata || {})) {
-    const segments = values.map((value) => ({
-      id: value,
-    }));
+type TargetingKeyValues = { [key: string]: string[] };
+function TargetingKeyValues(tdata: TargetingResponse | null): TargetingKeyValues {
+  const result: TargetingKeyValues = {}
 
-    if (segments.length > 0) {
-      result.push({
-        name: "optable.co",
-        /*
-         * 5001 is Optable Private Member Defined Audiences
-         * See: https://github.com/InteractiveAdvertisingBureau/openrtb/pull/81
-         */
-        ext: { segtax: 5001 },
-        segment: segments,
-      });
+  if (!tdata) {
+    return result;
+  }
+
+  for (const identifiers of (tdata.audience ?? [])) {
+    if (identifiers.keyspace) {
+      if (!(identifiers.keyspace in result)) {
+        result[identifiers.keyspace] = []
+      }
+      result[identifiers.keyspace].push(...identifiers.ids.map((el) => el.id))
     }
   }
 
@@ -78,8 +101,8 @@ export {
   Targeting,
   TargetingFromCache,
   TargetingClearCache,
-  TargetingKeyValues,
-  PrebidUserDataFromCache,
+  TargetingResponse,
   PrebidUserData,
+  TargetingKeyValues,
 };
 export default Targeting;

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -2,23 +2,20 @@ import type { OptableConfig } from "../config";
 import { fetch } from "../core/network";
 import { LocalStorage } from "../core/storage";
 
-type AudienceProvider = "optable.co"
-type UserProvider = "optable.co" | "uidapi.com"
-
 type Identifier = {
   id: string;
 };
 
 type AudienceIdentifiers = {
   ids: Identifier[];
-  provider: AudienceProvider;
+  provider: string;
   rtb_segtax: number; // taxonomy identifier for RTB UserSegments
-  keyspace?: string;   // GAM targeting key for optable.co audience provider
+  keyspace?: string;  // targeting key for integrations allowing for key/values targeting
 }
 
 type UserIdentifiers = {
   ids: Identifier[];
-  provider: UserProvider;
+  provider: string;
 }
 
 type TargetingResponse = {

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -1,9 +1,15 @@
 import type { OptableConfig } from "./config";
-import { PrebidUserData, PrebidUserDataFromCache, TargetingKeyValues } from "./edge/targeting";
 import type { WitnessProperties } from "./edge/witness";
 import type { ProfileTraits } from "./edge/profile";
 import { Identify } from "./edge/identify";
-import { Targeting, TargetingFromCache, TargetingClearCache } from "./edge/targeting";
+import {
+  TargetingKeyValues,
+  PrebidUserData,
+  TargetingResponse,
+  Targeting,
+  TargetingFromCache,
+  TargetingClearCache
+} from "./edge/targeting";
 import { Witness } from "./edge/witness";
 import { Profile } from "./edge/profile";
 import { sha256 } from "js-sha256";
@@ -22,11 +28,11 @@ class OptableSDK {
     );
   }
 
-  targeting(): Promise<TargetingKeyValues> {
+  targeting(): Promise<TargetingResponse> {
     return Targeting(this.dcn);
   }
 
-  targetingFromCache(): TargetingKeyValues | null {
+  targetingFromCache(): TargetingResponse | null {
     return TargetingFromCache(this.dcn);
   }
 
@@ -34,8 +40,22 @@ class OptableSDK {
     TargetingClearCache(this.dcn);
   }
 
+  async prebidUserData(): Promise<PrebidUserData> {
+    return PrebidUserData(await this.targeting())
+  }
+
   prebidUserDataFromCache(): PrebidUserData {
-    return PrebidUserDataFromCache(this.dcn);
+    const tdata = this.targetingFromCache()
+    return PrebidUserData(tdata);
+  }
+
+  async targetingKeyValues(): Promise<TargetingKeyValues> {
+    return TargetingKeyValues(await this.targeting())
+  }
+
+  targetingKeyValuesFromCache(): TargetingKeyValues {
+    const tdata = this.targetingFromCache()
+    return TargetingKeyValues(tdata);
   }
 
   witness(event: string, properties: WitnessProperties = {}): Promise<void> {
@@ -52,6 +72,14 @@ class OptableSDK {
 
   static cid(ppid: string): string {
     return ppid ? "c:" + ppid.trim() : "";
+  }
+
+  static TargetingKeyValues(tdata: TargetingResponse): TargetingKeyValues {
+    return TargetingKeyValues(tdata)
+  }
+
+  static PrebidUserData(tdata: TargetingResponse): PrebidUserData {
+    return PrebidUserData(tdata)
   }
 }
 


### PR DESCRIPTION
This updates the web-sdk to support the proposed v2/targeting response format which allows for passing down additional targeting information (user level, or other audience providers than optable for example).

To do so this:
- update `storage.LocalStorage` targeting to read/write targeting data from a new v2 targeting cache key, and falls back to legacy one on read if the new key isn't set
- update the internal structures of Targeting to map to the new edge response type
- expose new helpers like `targetingKeyValues` `prebidUserData` and their `*FromCache` counterpart to reduce the amount of changes required to map the generic targeting structure for a specific integration usecase
- update demos and doc to reflect those changes