### PR TITLE
uid2 token api and demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       SDK_URI: https://cdn.optable.co/web-sdk/latest/sdk.js
       SANDBOX_HOST: sandbox.optable.co
       SANDBOX_INSECURE: "false"
+      UID2_BASE_URL: https://prod.uidapi.com
     steps:
       - checkout
       - attach_workspace:
@@ -53,6 +54,7 @@ jobs:
           export SDK_URI="https://cdn.optable.co/web-sdk/${CIRCLE_TAG}/sdk.js"
           export SANDBOX_HOST="sandbox.optable.co"
           export SANDBOX_INSECURE="false"
+          export UID2_BASE_URL="https://prod.uidapi.com"
           make -j --output-sync
       - persist_to_workspace:
           root: "~"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ demos/vanilla/targeting/gam360-cached.html
 demos/vanilla/targeting/gam360.html
 demos/vanilla/targeting/prebid.html
 demos/vanilla/witness.html
+demos/vanilla/uid2_token/login.html

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ demos/vanilla/targeting/gam360.html
 demos/vanilla/targeting/prebid.html
 demos/vanilla/witness.html
 demos/vanilla/uid2_token/login.html
+demos/vanilla/uid2_token/index.html

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ demo-html:
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/gam360.html.tpl > demos/vanilla/nocookies/targeting/gam360.html
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/gam360-cached.html.tpl > demos/vanilla/nocookies/targeting/gam360-cached.html
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/prebid.html.tpl > demos/vanilla/nocookies/targeting/prebid.html
+	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/uid2_token/login.html.tpl > demos/vanilla/uid2_token/login.html
 
 .PHONY: demo-react
 demo-react: build-lib

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ deps:
 export SDK_URI ?= http://localhost:8181/sdk.js
 export SANDBOX_HOST ?= node1.cloud.test
 export SANDBOX_INSECURE ?= false
+export UID2_BASE_URL ?= https://operator-integ.uidapi.com
 
 .PHONY: demo-html
 demos: demo-html demo-react demo-npm
@@ -40,7 +41,8 @@ demo-html:
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/gam360.html.tpl > demos/vanilla/nocookies/targeting/gam360.html
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/gam360-cached.html.tpl > demos/vanilla/nocookies/targeting/gam360-cached.html
 	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/nocookies/targeting/prebid.html.tpl > demos/vanilla/nocookies/targeting/prebid.html
-	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE}' < demos/vanilla/uid2_token/login.html.tpl > demos/vanilla/uid2_token/login.html
+	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE} $${UID2_BASE_URL} ' < demos/vanilla/uid2_token/login.html.tpl > demos/vanilla/uid2_token/login.html
+	envsubst '$${SDK_URI} $${SANDBOX_HOST} $${SANDBOX_INSECURE} $${UID2_BASE_URL} ' < demos/vanilla/uid2_token/index.html.tpl > demos/vanilla/uid2_token/index.html
 
 .PHONY: demo-react
 demo-react: build-lib

--- a/demos/index-nocookies.html
+++ b/demos/index-nocookies.html
@@ -103,6 +103,15 @@
                   >.
                 </td>
               </tr>
+              <tr>
+                <td><a href="/vanilla/uid2_token/">uid2 integration</a></td>
+                <td>
+                  Shows how the
+                  <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/guides/publisher-client-side.md">standard UID2 integration workflow</a>
+                  for publishers can be implemented using the UID2 services operated by Optable and the
+                  <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a>.
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/demos/index.html
+++ b/demos/index.html
@@ -111,6 +111,15 @@
                   >.
                 </td>
               </tr>
+              <tr>
+                <td><a href="/vanilla/uid2_token/">uid2 integration</a></td>
+                <td>
+                  Shows how the
+                  <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/guides/publisher-client-side.md">standard UID2 integration workflow</a>
+                  for publishers can be implemented using the UID2 services operated by Optable and the
+                  <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a>.
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/demos/vanilla/uid2_token/index.html
+++ b/demos/vanilla/uid2_token/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Optable Web SDK Demos</title>
+    <meta name="description" content="Optable Web SDK Demos" />
+    <meta name="author" content="optable.co" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/skeleton.css" />
+    <link rel="icon" type="image/png" href="/images/favicon.png" />
+
+    <script src="https://prod.uidapi.com/static/js/uid2-sdk-2.0.0.js" type="text/javascript"></script> 
+
+    <style>
+      #uid2_state {
+        width: 100%;
+        overflow: auto;
+        table-layout: fixed;
+      }
+      #uid2_state .label {
+        white-space: nowrap;
+        padding-right: 20px;
+        width: 20%;
+      }
+      #uid2_state tr {
+        margin-top: 10px;
+        font-size: 12px;
+        table-layout: fixed;
+        width: 100%;
+        height: 100%;
+      }
+
+      .content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        position: center;
+      }
+
+      pre {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="row">
+        <div class="twelve column" style="margin-top: 5%;">
+          <a href="/"><img src="/images/logo.png" width="200" /></a>
+          <hr />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="twelve column">
+          <h4>Example: UID2 integration for publishers</h4>
+          <p>
+            This example illustrates the steps documented in the
+            <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/guides/publisher-client-side.md">UID2 SDK Integration Guide</a>.<br/>
+          </p>
+          <p>
+            The <code>__uid2.init</code> function from the <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a>
+            is used to load the UID2 identity from a first-party cookie, which contains an advertising token (or uid2 token) that can be used for targeted advertising.<br/>
+            If the UID2 identity is missing, then the user needs to authenticates and authorizes its creation.<br/>
+          </p>
+          <p>
+            In the background, the <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a> 
+            will continuously validate if the advertising token needs to be refreshed and refreshes it automatically when needed 
+            until the refresh token expires or the user opts out, at which point the UID2 identity is cleared and the user needs to
+            authorizes the creation of a new UID2 identity.
+          </p>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="column content">
+            <table id="uid2_state">
+              <tr><th class="label">Ready for Targeted Advertising:</th><td class="value"><pre id="targeted_advertising_ready"></pre></td></tr>
+              <tr><th class="label">UID2 Advertising Token:</th><td class="value"><pre id="advertising_token"></pre></td></tr>
+              <tr><th class="label">Is UID2 Login Required?</th><td class="value"><pre id="login_required"></pre></td></tr>
+              <tr><th class="label">UID2 Identity Updated Counter:</th><td class="value"><pre id="update_counter"></pre></td></tr>
+              <tr><th class="label">UID2 Identity Callback State:</th><td class="value"><pre id="identity_state"></pre></td></tr>
+            </table>
+          
+        </div>
+      </div>
+
+      <div class="row">
+        <button id="logout-button" class="button-primary">logout</button>
+        <button id="login-button" class="button-primary">login Required</button>
+      </div>
+
+      <div class="row">
+        <div class="twelve column" style="font-size: 0.8rem; padding: 10px;">
+          <center>
+            <a href="https://www.optable.co/">Home</a> | <a href="https://www.optable.co/company/contact">Contact</a> |
+            <a href="https://optable.co/privacy">Privacy</a> |
+            <a href="https://www.linkedin.com/company/optableco/">LinkedIn</a> |
+            <a href="https://twitter.com/optable_co">Twitter</a>
+          </center>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      let callbackCounter = 0;
+
+      function updateGuiElements(state) {
+        document.getElementById("targeted_advertising_ready").innerHTML = __uid2.getAdvertisingToken() ? "yes" : "no";
+        document.getElementById("advertising_token").innerHTML = String(__uid2.getAdvertisingToken());
+        document.getElementById("login_required").innerHTML = __uid2.isLoginRequired() ? "yes" : "no";
+        document.getElementById("update_counter").innerHTML = callbackCounter;
+        document.getElementById("identity_state").innerHTML = String(JSON.stringify(state, null, 2));
+
+        if (__uid2.isLoginRequired()) {
+          document.getElementById("logout-button").style.display = "none";
+          document.getElementById("login-button").style.display = "block";
+        } else {
+          document.getElementById("logout-button").style.display = "block";
+          document.getElementById("login-button").style.display = "none";
+        }
+      }
+
+      updateGuiElements(undefined);
+
+      function onUid2IdentityUpdated(state) {
+        ++callbackCounter;
+        updateGuiElements(state);
+      }
+
+      __uid2.init({
+        callback: onUid2IdentityUpdated,
+        baseUrl: "https://uid2.cloud.optable.co",
+      });
+
+      document.getElementById("logout-button").addEventListener("click", () => {
+        __uid2.disconnect();
+        document.cookie = "__uid_2=;expires=Tue, 1 Jan 1980 23:59:59 GMT;path=/";
+        updateGuiElements(undefined);
+      });
+
+      document.getElementById("login-button").addEventListener("click", () => {
+        location.href = "/vanilla/uid2_token/login.html";
+      });
+    </script>
+  </body>
+</html>

--- a/demos/vanilla/uid2_token/index.html.tpl
+++ b/demos/vanilla/uid2_token/index.html.tpl
@@ -135,7 +135,7 @@
 
       __uid2.init({
         callback: onUid2IdentityUpdated,
-        baseUrl: "https://uid2.cloud.optable.co",
+        baseUrl: "${UID2_BASE_URL}",
       });
 
       document.getElementById("logout-button").addEventListener("click", () => {

--- a/demos/vanilla/uid2_token/login.html.tpl
+++ b/demos/vanilla/uid2_token/login.html.tpl
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Optable Web SDK Demos</title>
+    <meta name="description" content="Optable Web SDK Demos" />
+    <meta name="author" content="optable.co" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/skeleton.css" />
+    <link rel="icon" type="image/png" href="/images/favicon.png" />
+
+    <script src="https://prod.uidapi.com/static/js/uid2-sdk-2.0.0.js" type="text/javascript"></script> 
+
+    <!-- Optable web-sdk loader start -->
+    <script type="text/javascript">
+      window.optable = window.optable || { cmd: [] };
+
+      optable.cmd.push(function () {
+        optable.instance = new optable.SDK({
+          host: "${SANDBOX_HOST}",
+          site: "web-sdk-demo",
+          insecure: JSON.parse("${SANDBOX_INSECURE}"),
+        });
+
+        optable.instance.tryIdentifyFromParams();
+      });
+    </script>
+    <script async src="${SDK_URI}"></script>
+    <!-- Optable web-sdk loader end -->
+
+    <style>
+      .code-result {
+        padding: 0.2rem 0.5rem;
+        margin: 0 0.2rem;
+        font-size: 90%;
+        background: #f1f1f1;
+        border: 1px solid #e1e1e1;
+        border-radius: 4px;
+        display: block;
+        padding: 1rem 1.5rem;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="row">
+        <div class="twelve column" style="margin-top: 5%;">
+          <a href="/"><img src="/images/logo.png" width="200" /></a>
+          <hr />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="twelve column">
+          <h4>Example: UID2 integration for publishers</h4>
+          <p>
+            Simple login page for the user to complete the UID2 login process.<br/>
+            <strong>
+                IMPORTANT: A real-life application must also display a form for the user to express their consent to targeted advertising.
+            </strong>
+          </p>
+          <p>
+            In this example, we use the <code>uid2Token</code> API to generate UID2 identity information containing an advertising token (or uid2 token),
+            which can be used for targeted advertising.<br/>
+            The <code>__uid2.init</code> function from the <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a>
+            is used to store the UID2 identity in a first-party cookie for use on subsequent page loads.<br/>
+            In the background, the <a href="https://github.com/UnifiedID2/uid2docs/blob/main/api/v2/sdks/client-side-identity.md">UID2 SDK</a> 
+            will continuously validate if the advertising token needs to be refreshed, if the refresh token expired or if the user opted out.
+          </p>
+        </div>
+        <p>
+            Note: The <code>optout@email.com</code> email can be used to test user opt out.
+            Using this email always generates an identity response with a refresh_token that results in a <code>optout</code> response when refreshed.
+        </p>
+      </div>
+
+      <div class="row">
+        <div class="twelve column" id="email-group">
+          <fieldset>
+            <div>
+              <label>Email Address:</label>
+              <input id="email" type="email" size="64" />
+            </div>
+            <button id="login-button" class="button-primary">Login</button>
+          </fieldset>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="twelve column code-result" id="result"></div>
+      </div>
+
+      <div class="row">
+        <div class="twelve column" style="font-size: 0.8rem; padding: 10px;">
+          <center>
+            <a href="https://www.optable.co/">Home</a> | <a href="https://www.optable.co/company/contact">Contact</a> |
+            <a href="https://optable.co/privacy">Privacy</a> |
+            <a href="https://www.linkedin.com/company/optableco/">LinkedIn</a> |
+            <a href="https://twitter.com/optable_co">Twitter</a>
+          </center>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      document.getElementById("login-button").addEventListener("click", () => {
+        const result = document.getElementById("result");
+        var email = document.getElementById("email").value;
+
+        result.innerHTML = "";
+
+        optable.instance
+          .uid2Token(optable.SDK.eid(email))
+          .then(function (identity) {
+            result.innerHTML += "UID2 identity:<br/>";
+            result.innerHTML += JSON.stringify(identity, null, 2);
+            result.innerHTML += "<br/><br/>";
+
+            function onUid2IdentityUpdated(state) {
+                if (__uid2.isLoginRequired()) {
+                    document.getElementById("email-group").style.display = "block"
+                    result.innerHTML = "";
+                } else {
+                    document.getElementById("email-group").style.display = "none"
+                    result.innerHTML += "Login completed: <a href=\"/vanilla/uid2_token/\">Proceed to the main page</a>"
+                    result.innerHTML += "<br/><br/>";
+                }
+            }
+
+            __uid2.init({
+                callback: onUid2IdentityUpdated,
+                baseUrl: "https://uid2.cloud.optable.co",
+                identity: identity
+            });
+          })
+          .catch((err) => {
+            result.innerHTML += "Error:<br/>" + err.message;
+          });
+      });
+    </script>
+  </body>
+</html>

--- a/demos/vanilla/uid2_token/login.html.tpl
+++ b/demos/vanilla/uid2_token/login.html.tpl
@@ -133,7 +133,7 @@
 
             __uid2.init({
                 callback: onUid2IdentityUpdated,
-                baseUrl: "https://uid2.cloud.optable.co",
+                baseUrl: "${UID2_BASE_URL}",
                 identity: identity
             });
           })

--- a/lib/edge/uid2_token.ts
+++ b/lib/edge/uid2_token.ts
@@ -1,0 +1,24 @@
+import type { OptableConfig } from "../config";
+import { fetch } from "../core/network";
+
+type Uid2TokenResponse = {
+    advertising_token: string;
+    RefreshToken: string;
+    IdentityExpires: number;
+	RefreshFrom: number;
+	RefreshExpires: number;
+	RefreshResponseKey: string;
+  };
+
+function Uid2Token(config: OptableConfig, id: string): Promise<Uid2TokenResponse> {
+  return fetch("/uid2/token", config, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(id),
+  });
+}
+
+export { Uid2Token };
+export default Uid2Token;

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -2,6 +2,7 @@ import type { OptableConfig } from "./config";
 import type { WitnessProperties } from "./edge/witness";
 import type { ProfileTraits } from "./edge/profile";
 import { Identify } from "./edge/identify";
+import { Uid2Token } from "./edge/uid2_token";
 import {
   TargetingKeyValues,
   PrebidUserData,
@@ -26,6 +27,10 @@ class OptableSDK {
       this.dcn,
       ids.filter((id) => id)
     );
+  }
+
+  uid2Token(id: string) {
+    return Uid2Token(this.dcn, id);
   }
 
   targeting(): Promise<TargetingResponse> {


### PR DESCRIPTION
The main page of the demo that lists all demos (only showing the uid2 demo in the listing):
<img width="992" alt="image" src="https://user-images.githubusercontent.com/3682773/232055299-1417eb82-1ce7-457d-ac5c-a9d2b815f2bb.png">

Initially, there is no UID2 identity information. So a login is required:
<img width="997" alt="image" src="https://user-images.githubusercontent.com/3682773/231939579-2d078ba6-e6c0-449e-bd80-f922186006a9.png">

Example login page:
<img width="962" alt="image" src="https://user-images.githubusercontent.com/3682773/231939739-e4177e22-bbe9-4e0f-a1b7-2ed7361fae9f.png">

UID2 identity information after login:
<img width="986" alt="image" src="https://user-images.githubusercontent.com/3682773/231940615-624a3c82-5173-4ef1-b75f-24418b123600.png">

<img width="986" alt="image" src="https://user-images.githubusercontent.com/3682773/231940761-a5375baa-49d6-4722-9477-468e15830c29.png">

When user opts out, login and consent are required again:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/3682773/232055949-f2d06bc3-c78f-458b-9e4e-5cc3407609ef.png">
