### PR TITLE
Add optional param to search for instead of oeid

### DIFF
--- a/lib/addons/try-identify.ts
+++ b/lib/addons/try-identify.ts
@@ -10,13 +10,13 @@ function maybeValidEID(eid: string): boolean {
   return eid.match(/^[a-f0-9]{64}$/i) !== null;
 }
 
-OptableSDK.prototype.tryIdentifyFromParams = function () {
+OptableSDK.prototype.tryIdentifyFromParams = function (paramKey?: string) {
   const qstr = new URLSearchParams(window.location.search);
   const keys = qstr.keys();
   var eid: string | null = "";
 
   for (const key of keys) {
-    if (key.match(/^oeid$/i)) {
+    if (key.match(new RegExp('^' + (paramKey || 'oeid') + '$', 'i'))) {
       eid = qstr.get(key);
       break;
     }

--- a/lib/addons/try-identify.ts
+++ b/lib/addons/try-identify.ts
@@ -14,9 +14,10 @@ OptableSDK.prototype.tryIdentifyFromParams = function (paramKey?: string) {
   const qstr = new URLSearchParams(window.location.search);
   const keys = qstr.keys();
   var eid: string | null = "";
+  var searchedParam = /^${paramKey || 'oeid'}$/i;
 
   for (const key of keys) {
-    if (key.match(new RegExp('^' + (paramKey || 'oeid') + '$', 'i'))) {
+    if (key.match(searchedParam)) {
       eid = qstr.get(key);
       break;
     }


### PR DESCRIPTION
some publishers cannot control the key used to push emails to the URL from an email click. We want to allow tryIdentifyFromParams to search for a publisher defined key.