### PR TITLE
New tests for try identify from params

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,10 +595,7 @@ On your website destination page, you can call a helper method provided by the S
   window.optable = window.optable || { cmd: [] };
   optable.cmd.push(function () {
     optable.instance = new optable.SDK({ host: "dcn.customer.com", site: "my-site" });
-    optable.instance.tryIdentifyFromParams(); // uses default parameter key 'oeid'
-    // or specify custom parameter key
-    // https://www.mysite.com?origin=newsletter&user_id=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789&foo=bar
-    // optable.instance.tryIdentifyFromParams('user_id');
+    optable.instance.tryIdentifyFromParams();
   });
 </script>
 ```

--- a/lib/addons/try-identify.test.js
+++ b/lib/addons/try-identify.test.js
@@ -16,7 +16,7 @@ describe("tryIdentifyFromParams", () => {
     };
   }
 
-  test("is correct", () => {
+  test("works when no key is specified and value is a 64 characters hexadecimal", () => {
     setURL(
       "http://some.domain.com/some/path?some=query&something=else&oeid=a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3&foo=bar&baz"
     );
@@ -27,14 +27,32 @@ describe("tryIdentifyFromParams", () => {
     expect(SDK.identify.mock.calls[0][0]).toEqual(expected);
   });
 
-  test("identify not called when oeid absent", () => {
+  test("works with custom param key and value is a 64 characters hexadecimal", () => {
+    setURL(
+      "http://some.domain.com/some/path?some=query&something=else&customParamKey=a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3&foo=bar&baz"
+    );
+    SDK.tryIdentifyFromParams("customParamKey");
+
+    const expected = "e:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3";
+    expect(SDK.identify.mock.calls.length).toBe(1);
+    expect(SDK.identify.mock.calls[0][0]).toEqual(expected);
+  });
+  
+  test("identify not called when default key (oeid) is absent", () => {
     setURL("http://some.domain.com/some/path?some=query&something=else");
     SDK.tryIdentifyFromParams();
 
     expect(SDK.identify.mock.calls.length).toBe(0);
   });
+  
+  test("identify not called when custom param key is absent", () => {
+    setURL("http://some.domain.com/some/path?some=query&something=else");
+    SDK.tryIdentifyFromParams("customParamKey");
 
-  test("identify not called when oeid not a SHA256 value", () => {
+    expect(SDK.identify.mock.calls.length).toBe(0);
+  });
+
+  test("identify not called when value is not a 64 characters hexadecimal", () => {
     setURL(
       "http://some.domain.com/some/path?some=query&something=else&oeid=AAAAAAAa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3&foo=bar&baz"
     );
@@ -43,7 +61,7 @@ describe("tryIdentifyFromParams", () => {
     expect(SDK.identify.mock.calls.length).toBe(0);
   });
 
-  test("detects oeid regardless of case", () => {
+  test("detects key regardless of case", () => {
     setURL(
       "http://some.domain.com/some/path?some=query&something=else&oEId=A665A45920422F9D417E4867EFDC4FB8A04A1F3FFF1FA07E998E86f7f7A27AE3&foo=bar&baz"
     );


### PR DESCRIPTION
tryIdentifyFromParams now accept a publisher-defined key, instead of the unspecified default 'oeid'