### PR TITLE
Add init call on creation of SDK

### DIFF
--- a/lib/addons/try-identify.test.js
+++ b/lib/addons/try-identify.test.js
@@ -6,7 +6,7 @@ describe("tryIdentifyFromParams", () => {
 
   beforeEach(() => {
     delete window.location;
-    SDK = new OptableSDK({ host: "localhost", site: "test" });
+    SDK = new OptableSDK({ host: "localhost", site: "test" }, false);
     SDK.identify = jest.fn();
   });
 

--- a/lib/edge/init.ts
+++ b/lib/edge/init.ts
@@ -1,0 +1,14 @@
+import type { OptableConfig } from "../config";
+import { fetch } from "../core/network";
+
+function Init(config: OptableConfig): Promise<void> {
+  return fetch("/init", config, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+export { Init };
+export default Init;

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -3,6 +3,7 @@ import type { WitnessProperties } from "./edge/witness";
 import type { ProfileTraits } from "./edge/profile";
 import { Identify } from "./edge/identify";
 import { Uid2Token } from "./edge/uid2_token";
+import { Init } from "./edge/init";
 import { Site, SiteResponse } from "./edge/site";
 import {
   TargetingKeyValues,
@@ -20,8 +21,15 @@ import { sha256 } from "js-sha256";
 class OptableSDK {
   public sandbox: OptableConfig; // legacy
 
-  constructor(public dcn: OptableConfig) {
+  constructor(public dcn: OptableConfig, writePassport: boolean = true) {
     this.sandbox = dcn; // legacy
+    writePassport && Init(dcn);
+  }
+
+  init() {
+    return Init(
+      this.dcn,
+    );
   }
 
   identify(...ids: string[]) {


### PR DESCRIPTION
This PR is dependent on https://github.com/Optable/optable-sandbox/pull/5021 

This PR adds the init call in the constructor of the SDK. This allows for a Passport write (to the cookie or to local storage) to occur before the first identify call. 

## Questions to Reviewers:
I added a boolean parameter to OptableSDK (which defaults to true) that determines whether the init call is run or not in the constructor. This is mainly used to be able to instantiate an OptableSDK without running the API in the tests. Should we have this functionality or should we refactor the tests to able ignore the API call?

## Testing:
#### No init call:
Passport is not contained in the first identify call (see path).
<img width="946" alt="image" src="https://github.com/Optable/optable-sandbox/assets/45809529/315c151b-e089-4401-8f63-ed6782147478">

Passport is contained in the second identify call.
<img width="1154" alt="image" src="https://github.com/Optable/optable-sandbox/assets/45809529/ec9a235c-2278-49e5-a164-0c79fa3e4afb">

#### With init call:
The init call which runs on instantiation.
<img width="737" alt="image" src="https://github.com/Optable/optable-sandbox/assets/45809529/44b54583-bbac-4adb-a86d-03f984700602">

Passport is contained the first identify call.
<img width="1129" alt="image" src="https://github.com/Optable/optable-sandbox/assets/45809529/f0afba4e-de9c-4efc-8e9f-b62ca05ecb06">