### PR TITLE
Document mergeConfig rather than setConfig in anything related to pbjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ For bidder adapters that do not support SDA, but that do support targeting priva
         }
       }
 
-      pbjs.setConfig({
+      pbjs.mergeConfig({
         ix: {
           firstPartyData: fpd,
         },

--- a/demos/ads/protected-audience/publisher-prebid.html.tpl
+++ b/demos/ads/protected-audience/publisher-prebid.html.tpl
@@ -40,7 +40,7 @@
         pbjs.que = pbjs.que || [];
 
         pbjs.que.push(function() {
-          pbjs.setConfig({
+          pbjs.mergeConfig({
             optableOrtbUrl: "https://${ADS_HOST}/${ADS_REGION}/ortb2/v1/ssp/bid",
             fledgeForGpt: {
               enabled: true,

--- a/demos/integration/lmpid-prebid-gpt.html.tpl
+++ b/demos/integration/lmpid-prebid-gpt.html.tpl
@@ -167,7 +167,7 @@ googletag.cmd.push(function () {
 
 pbjs.que.push(function () {
   // Enable Loblaw Media Private ID user ID module (lmpid):
-  pbjs.setConfig({ userSync: { userIds: [{ name: "lmpid" }] } })
+  pbjs.mergeConfig({ userSync: { userIds: [{ name: "lmpid" }] } })
 
   // Configure some ad units.
   // Note that while it's not relevant for LMPID integration,
@@ -291,7 +291,7 @@ olivia.anderson@acme.test</code></pre>
       });
 
       pbjs.que.push(function () {
-        pbjs.setConfig({
+        pbjs.mergeConfig({
           userSync: { userIds: [{ name: "lmpid" }] },
         });
 

--- a/demos/vanilla/nocookies/targeting/prebid.html.tpl
+++ b/demos/vanilla/nocookies/targeting/prebid.html.tpl
@@ -156,7 +156,7 @@
         optable.cmd.push(function () {
           const ortb2 = optable.instance.prebidORTB2FromCache();
 
-          pbjs.setConfig({
+          pbjs.mergeConfig({
             ortb2,
             priceGranularity: "low",
             userSync: {
@@ -222,7 +222,7 @@
           <h4>Example: targeting API: Prebid.js</h4>
           <p>
             Shows how to load active cohorts for a visitor and pass them to Prebid.js via
-            <a href="https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-fpd">setConfig-fpd</a>.
+            <a href="https://docs.prebid.org/dev-docs/publisher-api-reference/mergeConfig.html">mergeConfig</a>.
             It's assumed in this example that your primary ad server is
             <a href="https://admanager.google.com/home/">Google Ad Manager</a> (GAM) and that you are integrated with it
             using the

--- a/demos/vanilla/targeting/prebid.html.tpl
+++ b/demos/vanilla/targeting/prebid.html.tpl
@@ -155,7 +155,7 @@
         optable.cmd.push(function () {
           const ortb2 = optable.instance.prebidORTB2FromCache();
 
-          pbjs.setConfig({
+          pbjs.mergeConfig({
             ortb2: ortb2,
             priceGranularity: "low",
             userSync: {


### PR DESCRIPTION
Align documentation to suggest using `mergeConfig` rather than `setConfig` in anything related to pbjs. https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html is destructive (overrides any previous configuration) while `mergeConfig` recursively merges configuration https://docs.prebid.org/dev-docs/publisher-api-reference/mergeConfig.html.