### PR TITLE
topics: Obtain optable's observed topics through gateway frame

### DIFF
--- a/lib/addons/paapi.ts
+++ b/lib/addons/paapi.ts
@@ -122,12 +122,11 @@ OptableSDK.prototype.runAdAuction = async function(domID: string, defaults: Part
  */
 OptableSDK.prototype.joinAdInterestGroups = async function() {
   const siteConfig = await this.site();
-  const pixel = document.createElement("iframe");
   if (!siteConfig.interestGroupPixel) {
     throw ("origin not enabled for protected audience apis");
   }
   const pixelURL = new URL(siteConfig.interestGroupPixel);
-
+  const pixel = document.createElement("iframe");
   pixel.src = pixelURL.toString()
   pixel.allow = "join-ad-interest-group " + pixelURL.origin;
   pixel.style.display = "none";

--- a/lib/addons/topics-api.ts
+++ b/lib/addons/topics-api.ts
@@ -1,27 +1,35 @@
 import OptableSDK from "../sdk";
+interface BrowsingTopic {
+  configVersion: string;
+  modelVersion: string;
+  taxonomyVersion: string;
+  topic: number;
+  version: string;
+}
 
 declare module "../sdk" {
+
   export interface OptableSDK {
-    getTopics: () => Promise<void>;
+    getTopics: () => Promise<BrowsingTopic[]>;
   }
 }
 
 /*
  * getTopics injects an iframe into the page that obtains the browsingTopics observed by optable.
  */
-OptableSDK.prototype.getTopics = async function() {
+OptableSDK.prototype.getTopics = async function(): Promise<BrowsingTopic[]> {
   const siteConfig = await this.site();
   if (!siteConfig.getTopicsURL) {
     throw ("origin not enabled for topics api");
   }
   const getTopicsURL = new URL(siteConfig.getTopicsURL);
   const topicsFrame = document.createElement("iframe");
-  topicsFrame.src = pixelURL.toString()
+  topicsFrame.src = getTopicsURL.toString()
   topicsFrame.allow = "browsing-topics " + getTopicsURL.origin;
   topicsFrame.style.display = "none";
 
-  const topicsPromise = new Promise<void>((resolve, reject) => {
-    window.addEventListener("message", (event: any) => {
+  const topicsPromise = new Promise<BrowsingTopic[]>((resolve, reject) => {
+    window.addEventListener("message", (event: MessageEvent<{ error?: Error, result: BrowsingTopic[] }>) => {
       if (event.source !== topicsFrame.contentWindow) {
         return
       }

--- a/lib/edge/site.ts
+++ b/lib/edge/site.ts
@@ -4,6 +4,7 @@ import { fetch } from "../core/network";
 type SiteResponse = {
   interestGroupPixel: string;
   auctionConfigURL: string;
+  getTopicsURL: string;
 };
 
 async function Site(config: Required<OptableConfig>): Promise<SiteResponse> {


### PR DESCRIPTION
This updates recently introduced `getTopics()` to go through optable's topics frames to obtain browsing topics rather than calling it directly on current document. 