### PR TITLE
Drop googletag secure signal cache mangling

### DIFF
--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -46,7 +46,7 @@ class LocalStorage {
         //
         // Starting v2 this is returned in the targeting payload directly
         rtb_segtax: 5001,
-        ids: [].concat(...[values as any]).map((id: any) => ({id: String(id)})),
+        ids: [].concat(...[values as any]).map((id: any) => ({ id: String(id) })),
       }
     })
 
@@ -86,13 +86,6 @@ class LocalStorage {
       return
     }
 
-    // Invalidate the secure signals provider cache as it's unclear
-    // for how long the secure signals are cached and while LMPID have a 45 days lifetime receivers
-    // may decide to implement short PID lifetimes.
-    //
-    // HACK: Delete GPT secure signals cache directly for lmpidProvider, this is undocumented and could
-    // break in the future.
-    window.localStorage.removeItem(`_GESPSK-${lmpidProvider}`);
     window.localStorage.setItem(this.lmpidKey, provider.ids?.[0]?.id ?? "");
   }
 


### PR DESCRIPTION
The GPT cache mangling is causing problems as googletag uses it as the source of truth to know which secure signals to send. Based on observation GPT caches for 7 days which is acceptable with current implementation of LMPID.
This removes the lmpid secure signals cache clear on targeting() response storage.