### PR TITLE
Fix injectTopics to not return promise

### DIFF
--- a/lib/addons/topics-api.test.js
+++ b/lib/addons/topics-api.test.js
@@ -1,5 +1,5 @@
 import OptableSDK from "../sdk";
-import "../../lib/addons/topics-api.ts";
+import "./topics-api.ts";
 
 describe("OptableSDK - ingestTopics", () => {
   let SDK;
@@ -13,10 +13,13 @@ describe("OptableSDK - ingestTopics", () => {
   test("profiles topics when getTopics returns topics", async () => {
     // Mock the getTopics method to return topics
     const topics = [{ topic: 1, configVersion: "v1", modelVersion: "v1", taxonomyVersion: "v1", version: "v1" }];
-    SDK.getTopics = jest.fn().mockResolvedValue(topics);
+    const getTopicsPromise = Promise.resolve(topics);
+    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
 
     // Call ingestTopics
-    await SDK.ingestTopics();
+    SDK.ingestTopics();
+
+    await getTopicsPromise;
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);
@@ -26,22 +29,13 @@ describe("OptableSDK - ingestTopics", () => {
 
   test("does not profile topics when getTopics returns an empty array", async () => {
     // Mock the getTopics method to return an empty array
-    SDK.getTopics = jest.fn().mockResolvedValue([]);
+    const getTopicsPromise = Promise.resolve([]);
+    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
 
     // Call ingestTopics
-    await SDK.ingestTopics();
+    SDK.ingestTopics();
 
-    // Expectations
-    expect(SDK.getTopics).toHaveBeenCalledTimes(1);
-    expect(SDK.profile).not.toHaveBeenCalled();
-  });
-
-  test("does not profile topics when getTopics throws an error", async () => {
-    // Mock the getTopics method to throw an error
-    SDK.getTopics = jest.fn().mockRejectedValue(new Error("Failed to retrieve topics"));
-
-    // Call ingestTopics
-    await SDK.ingestTopics();
+    await getTopicsPromise;
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);
@@ -50,10 +44,13 @@ describe("OptableSDK - ingestTopics", () => {
 
   test("does not profile topics when getTopics fails silently", async () => {
     // Mock the getTopics method to throw an error
-    SDK.getTopics = jest.fn().mockRejectedValue(new Error("Failed to retrieve topics"));
+    const getTopicsPromise = Promise.reject(new Error("Failed to retrieve topics"));
+    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
 
     // Call ingestTopics
-    await SDK.ingestTopics();
+    SDK.ingestTopics();
+
+    await getTopicsPromise.catch(() => { });
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);

--- a/lib/addons/topics-api.ts
+++ b/lib/addons/topics-api.ts
@@ -50,12 +50,12 @@ OptableSDK.prototype.getTopics = async function(): Promise<BrowsingTopic[]> {
 /*
  * ingestTopics invokes getTopics then makes a profile() call with the resulting topics, if any.
  */
-OptableSDK.prototype.ingestTopics = async function (): Promise<void> {
-    const topics = await this.getTopics().catch(() => {});
-    if (topics && topics.length > 0) {
-        this.profile({
-            topics_api: topics.map(topic => JSON.stringify(topic)).join('|')
-        });
-    }
-    return;
+OptableSDK.prototype.ingestTopics = function() {
+  this.getTopics()
+    .then((topics) => {
+      if (!topics.length) { return }
+      const topics_api = topics.map(topic => JSON.stringify(topic)).join('|')
+      this.profile({ topics_api })
+    })
+    .catch(() => { })
 }


### PR DESCRIPTION
injectTopics current implementation is a bit strange as the promise it returns only represent underlying getTopics() promise (with rejection muting) and not the actual profile() call. The initial intention was to use this as fire&forget and not bubble up any errors or promise rejection to user, the promise it returned was solely due to using async/await syntax.

This fixes it to not return any promise