### PR TITLE
topics: Move to new payload

### DIFF
--- a/lib/addons/topics-api.test.js
+++ b/lib/addons/topics-api.test.js
@@ -12,30 +12,35 @@ describe("OptableSDK - ingestTopics", () => {
 
   test("profiles topics when getTopics returns topics", async () => {
     // Mock the getTopics method to return topics
-    const topics = [{ topic: 1, configVersion: "v1", modelVersion: "v1", taxonomyVersion: "v1", version: "v1" }];
-    const getTopicsPromise = Promise.resolve(topics);
-    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
+    const topics = [
+      { topic: 583, configVersion: "chrome.2", modelVersion: "4", taxonomyVersion: "2", version: "chrome.2:2:4" },
+      { topic: 582, configVersion: "chrome.2", modelVersion: "4", taxonomyVersion: "2", version: "chrome.2:2:4" },
+      { topic: 583, configVersion: "chrome.1", modelVersion: "4", taxonomyVersion: "1", version: "chrome.1:2:4" },
+      { topic: 582, configVersion: "chrome.1", modelVersion: "4", taxonomyVersion: "1", version: "chrome.1:2:4" }
+    ];
+    SDK.getTopics = jest.fn().mockResolvedValue(topics);
 
     // Call ingestTopics
     SDK.ingestTopics();
 
-    await getTopicsPromise;
+    await new Promise(process.nextTick);
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);
-    const expectedTopicsApi = topics.map(topic => `taxonomy version ${topic.taxonomyVersion}, topic ${topic.topic}`).join('|');
-    expect(SDK.profile).toHaveBeenCalledWith({ topics_api: expectedTopicsApi });
+    expect(SDK.profile).toHaveBeenCalledWith({
+      topics_v2: "583,582",
+      topics_v1: "583,582",
+    });
   });
 
   test("does not profile topics when getTopics returns an empty array", async () => {
     // Mock the getTopics method to return an empty array
-    const getTopicsPromise = Promise.resolve([]);
-    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
+    SDK.getTopics = jest.fn().mockResolvedValue([]);
 
     // Call ingestTopics
     SDK.ingestTopics();
 
-    await getTopicsPromise;
+    await new Promise(process.nextTick);
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);
@@ -44,13 +49,12 @@ describe("OptableSDK - ingestTopics", () => {
 
   test("does not profile topics when getTopics fails silently", async () => {
     // Mock the getTopics method to throw an error
-    const getTopicsPromise = Promise.reject(new Error("Failed to retrieve topics"));
-    SDK.getTopics = jest.fn().mockImplementation(() => getTopicsPromise);
+    SDK.getTopics = jest.fn().mockRejectedValue(new Error("Failed to retrieve topics"))
 
     // Call ingestTopics
     SDK.ingestTopics();
 
-    await getTopicsPromise.catch(() => { });
+    await new Promise(process.nextTick);
 
     // Expectations
     expect(SDK.getTopics).toHaveBeenCalledTimes(1);

--- a/lib/addons/topics-api.ts
+++ b/lib/addons/topics-api.ts
@@ -54,8 +54,19 @@ OptableSDK.prototype.ingestTopics = function() {
   this.getTopics()
     .then((topics) => {
       if (!topics.length) { return }
-      const topics_api = topics.map(topic => `taxonomy version ${topic.taxonomyVersion}, topic ${topic.topic}`).join('|');
-      this.profile({ topics_api });
+
+      const traits = topics.reduce((acc, topic) => {
+        const traitKey = "topics_v" + topic.taxonomyVersion;
+        if (acc[traitKey]) {
+          acc[traitKey] += ",";
+        } else {
+          acc[traitKey] = "";
+        }
+        acc[traitKey] += String(topic.topic);
+        return acc;
+      }, {} as Record<string, string>);
+
+      this.profile(traits);
     })
     .catch(() => { });
 }


### PR DESCRIPTION
Prefer to emit one trait key per taxonomy version, with the observed topic numbers as the value (as trait value array)