### PR TITLE
Fix ads prebid demo regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           export SDK_URI="https://cdn.optable.co/web-sdk/${CIRCLE_TAG}/sdk.js"
           export ADS_HOST="ads.optable.co"
           export ADS_REGION="ca"
+          export ADS_SITE="4fe7c1ce-7c7d-4718-a0b8-5195e489319f"
           export DCN_HOST="sandbox.optable.co"
           export DCN_SITE="web-sdk-demo"
           export DCN_ID="optable"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ export DCN_INIT ?= true
 export DCN_ID ?= optable
 export ADS_HOST ?= ads.optable.co
 export ADS_REGION ?= ca
+export ADS_SITE ?= 4fe7c1ce-7c7d-4718-a0b8-5195e489319f
 export UID2_BASE_URL ?= https://operator-integ.uidapi.com
 
 .PHONY: demo-html
@@ -39,6 +40,7 @@ DEMO_VARS:='\
 	DCN_ID=$${DCN_ID} \
 	DCN_INSECURE=$${DCN_INSECURE} \
 	DCN_INIT=$${DCN_INIT} \
+	ADS_SITE=$${ADS_SITE} \
 	ADS_HOST=$${ADS_HOST} \
 	ADS_REGION=$${ADS_REGION} \
 	UID2_BASE_URL=$${UID2_BASE_URL} \

--- a/demos/ads/protected-audience/publisher-prebid.html.tpl
+++ b/demos/ads/protected-audience/publisher-prebid.html.tpl
@@ -61,7 +61,7 @@
             {
               code: slotID,
               mediaTypes: { banner: { sizes: bannerSizes } },
-              bids: [{ bidder: "optable", params: { site: "${DCN_ID}/${DCN_SITE}" } }]
+              bids: [{ bidder: "optable", params: { site: "${ADS_SITE}" } }]
             },
           );
 


### PR DESCRIPTION
We now reference auction config by global site id, not dcn slugs.