### PR TITLE
Allow installing GPT componentAuction for all slots on the page easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export ADS_REGION ?= ca
 export ADS_SITE ?= 4fe7c1ce-7c7d-4718-a0b8-5195e489319f
 export UID2_BASE_URL ?= https://operator-integ.uidapi.com
 
-.PHONY: demo-html
+.PHONY: demos
 demos: demo-html demo-react demo-npm
 
 DEMO_VARS:='\

--- a/demos/ads/protected-audience/publisher-gam.html.tpl
+++ b/demos/ads/protected-audience/publisher-gam.html.tpl
@@ -52,7 +52,7 @@
         <script>
           googletag.cmd.push(function() {
             optable.cmd.push(() => {
-              optable.instance.installGPTSlotAuctionConfig("div-ad-fledge").then(() => {
+              optable.instance.installGPTAuctionConfigs().then(() => {
                 googletag.display("div-ad-fledge");
               });
             })

--- a/lib/addons/paapi.ts
+++ b/lib/addons/paapi.ts
@@ -55,7 +55,7 @@ function elementInnerSize(element: HTMLElement): Size {
 
 /*
  * installGPTAuctionConfigs obtains the auction configuration for the current origin
- * and installs it into the page GPT slots, optionally filtered to a given domID.
+ * and installs it into the page GPT slots, optionally filtered.
  */
 
 OptableSDK.prototype.installGPTAuctionConfigs = async function(filter?: GPTSlotFilter): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@babel/plugin-transform-runtime": "^7.12.1",
         "@babel/preset-env": "^7.12.1",
         "@babel/preset-typescript": "^7.12.1",
+        "@types/googletag": "^3.1.3",
         "@types/jest": "^26.0.15",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.2",
@@ -2402,6 +2403,12 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "node_modules/@types/googletag": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/googletag/-/googletag-3.1.3.tgz",
+      "integrity": "sha512-KNLZrok/w8KbM/llujryQa1dWdDn5ZcgfsNAKtB7pDy8SrlRd/HWvx5w2+pJeTsEnhqGuQFbChzwd181fud7gg==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -11956,6 +11963,12 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "@types/googletag": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/googletag/-/googletag-3.1.3.tgz",
+      "integrity": "sha512-KNLZrok/w8KbM/llujryQa1dWdDn5ZcgfsNAKtB7pDy8SrlRd/HWvx5w2+pJeTsEnhqGuQFbChzwd181fud7gg==",
       "dev": true
     },
     "@types/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
+    "@types/googletag": "^3.1.3",
     "@types/jest": "^26.0.15",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
BREAKING: 

Rename installGPTSlotAuctionConfig to installGPTAuctionConfigs which will install the site's auctionConfig for all the slots on the page. An optional filter `(googletag.Slot) => boolean` can be passed to filter specific slots on the page.

This takes the opportunity to introduce `@types/googletag` typescript typings to better check our interactions with googletag.