### PR TITLE
paapi: Obtain auction config from cache

### DIFF
--- a/demos/ads/protected-audience/publisher-gam.html.tpl
+++ b/demos/ads/protected-audience/publisher-gam.html.tpl
@@ -32,6 +32,10 @@
         googletag.defineSlot(slotID, [[300, 250]], "div-ad-fledge").addService(googletag.pubads());
         googletag.pubads().enableSingleRequest();
         googletag.enableServices();
+
+        optable.cmd.push(() => {
+          optable.instance.installGPTAuctionConfigs();
+        })
       });
     </script>
   </head>
@@ -51,11 +55,7 @@
       <div id='div-ad-fledge' style='width: 300px; height: 250px; border: 1px dotted black;'>
         <script>
           googletag.cmd.push(function() {
-            optable.cmd.push(() => {
-              optable.instance.installGPTAuctionConfigs().then(() => {
-                googletag.display("div-ad-fledge");
-              });
-            })
+            googletag.display("div-ad-fledge");
           });
         </script>
       </div>

--- a/lib/edge/site.ts
+++ b/lib/edge/site.ts
@@ -2,9 +2,25 @@ import type { OptableConfig } from "../config";
 import { fetch } from "../core/network";
 import { LocalStorage } from "../core/storage";
 
+type Size = {
+  width: string;
+  height: string;
+}
+
+
+type AuctionConfig = {
+  seller: string;
+  decisionLogicURL: string;
+  requestedSize?: Size;
+  interestGroupBuyers: string[];
+  resolveToConfig?: boolean;
+  auctionSignals?: any;
+}
+
+
 type SiteResponse = {
   interestGroupPixel: string;
-  auctionConfigURL: string;
+  auctionConfig?: AuctionConfig | null;
   getTopicsURL: string;
 };
 
@@ -26,5 +42,5 @@ function SiteFromCache(config: Required<OptableConfig>): SiteResponse | null {
   return ls.getSite();
 }
 
-export { Site, SiteResponse, SiteFromCache };
+export { Site, SiteResponse, SiteFromCache, Size, AuctionConfig };
 export default Site;


### PR DESCRIPTION
This updates the paapi module to obtain the site's auctionConfig from cache instead of the one fetched at sdk init time.
This saves users from waiting on installGPTAuctionConfigs before googletag.display/refresh calls at the cost of having no auction config installed on the first time visit.