### PR TITLE
ps: Test for feature support

### DIFF
--- a/lib/addons/paapi.ts
+++ b/lib/addons/paapi.ts
@@ -93,6 +93,11 @@ OptableSDK.prototype.installGPTAuctionConfigs = function (filter?: GPTSlotFilter
  * runAdAuction runs an ad auction locally for a given spot dom ID.
  */
 OptableSDK.prototype.runAdAuction = async function (domID: string): Promise<boolean> {
+  const supported = "runAdAuction" in navigator;
+  if (!supported) {
+    throw "run-ad-auction not supported";
+  }
+
   const spot = document.getElementById(domID);
   if (!spot) {
     throw "spot not found";
@@ -127,6 +132,11 @@ OptableSDK.prototype.runAdAuction = async function (domID: string): Promise<bool
  * joinAdInterestGroups injects an iframe into the page that tags the device into the matching audiences interest group.
  */
 OptableSDK.prototype.joinAdInterestGroups = async function () {
+  const supported = "joinAdInterestGroup" in navigator;
+  if (!supported) {
+    throw "join-ad-interest-group not supported";
+  }
+
   const siteConfig = await this.site();
   if (!siteConfig.interestGroupPixel) {
     throw "origin not enabled for protected audience apis";

--- a/lib/addons/topics-api.ts
+++ b/lib/addons/topics-api.ts
@@ -18,6 +18,11 @@ declare module "../sdk" {
  * getTopics injects an iframe into the page that obtains the browsingTopics observed by optable.
  */
 OptableSDK.prototype.getTopics = async function (): Promise<BrowsingTopic[]> {
+  const supported = "browsingTopics" in document;
+  if (!supported) {
+    throw "browsing-topics not supported";
+  }
+
   const siteConfig = await this.site();
   if (!siteConfig.getTopicsURL) {
     throw "origin not enabled for topics api";


### PR DESCRIPTION
Test for feature support in paapi and topicsapi before injecting the frame. This avoids unnecessary calls to the dcn backend.

While it's usually also recommended to test for featurePolicy, it's usually done at the document level (since it can be controlled per origin by the website owner) that ends up calling the apis, this is why it's omitted here and is done from within the injected iframes.