### PR TITLE
set lmpid only if exists

### DIFF
--- a/lib/addons/gpt.ts
+++ b/lib/addons/gpt.ts
@@ -63,7 +63,7 @@ OptableSDK.prototype.installGPTSecureSignals = function () {
       gpt.secureSignalProviders.push({
         id: lmpidProvider,
         collectorFunction: function () {
-          return lmpid;
+          return Promise.resolve(lmpid);
         },
       });
     });

--- a/lib/addons/gpt.ts
+++ b/lib/addons/gpt.ts
@@ -58,13 +58,17 @@ OptableSDK.prototype.installGPTSecureSignals = function () {
   window.googletag = window.googletag || { cmd: [], secureSignalProviders: [] };
   const gpt = window.googletag;
 
-  gpt.cmd.push(function () {
-    // Install lmpid secure signal
-    gpt.secureSignalProviders.push({
-      id: lmpidProvider,
-      collectorFunction: function () {
-        return Promise.resolve(sdk.lmpidFromCache() ?? "");
-      },
+  // Check if lmpidFromCache exists and returns a truthy, non-empty string
+  const lmpid = Promise.resolve(sdk.lmpidFromCache());
+  if (lmpid) {
+    gpt.cmd.push(function () {
+      // Install lmpid secure signal
+      gpt.secureSignalProviders.push({
+        id: lmpidProvider,
+        collectorFunction: function () {
+          return lmpid
+        },
+      });
     });
-  });
+  }
 };

--- a/lib/addons/gpt.ts
+++ b/lib/addons/gpt.ts
@@ -51,22 +51,19 @@ OptableSDK.prototype.installGPTEventListeners = function () {
  * installGPTSecureSignals() sets up loblaw media private ID secure signals on GPT from targeting.
  */
 OptableSDK.prototype.installGPTSecureSignals = function () {
-  // Next time we get called is a no-op:
   const sdk = this;
   sdk.installGPTSecureSignals = function () {};
 
   window.googletag = window.googletag || { cmd: [], secureSignalProviders: [] };
   const gpt = window.googletag;
 
-  // Check if lmpidFromCache exists and returns a truthy, non-empty string
-  const lmpid = Promise.resolve(sdk.lmpidFromCache());
+  const lmpid = await Promise.resolve(sdk.lmpidFromCache());
   if (lmpid) {
     gpt.cmd.push(function () {
-      // Install lmpid secure signal
       gpt.secureSignalProviders.push({
         id: lmpidProvider,
         collectorFunction: function () {
-          return lmpid
+          return Promise.resolve(lmpid);
         },
       });
     });

--- a/lib/addons/gpt.ts
+++ b/lib/addons/gpt.ts
@@ -57,13 +57,13 @@ OptableSDK.prototype.installGPTSecureSignals = function () {
   window.googletag = window.googletag || { cmd: [], secureSignalProviders: [] };
   const gpt = window.googletag;
 
-  const lmpid = await Promise.resolve(sdk.lmpidFromCache());
+  const lmpid = sdk.lmpidFromCache();
   if (lmpid) {
     gpt.cmd.push(function () {
       gpt.secureSignalProviders.push({
         id: lmpidProvider,
         collectorFunction: function () {
-          return Promise.resolve(lmpid);
+          return lmpid
         },
       });
     });

--- a/lib/addons/gpt.ts
+++ b/lib/addons/gpt.ts
@@ -63,7 +63,7 @@ OptableSDK.prototype.installGPTSecureSignals = function () {
       gpt.secureSignalProviders.push({
         id: lmpidProvider,
         collectorFunction: function () {
-          return lmpid
+          return lmpid;
         },
       });
     });


### PR DESCRIPTION
prevents Google from caching "" and having the LMPID non-existent for 1+ week.