### PR TITLE
Improve navigation between advertiser and publisher in PAAPI demos

### DIFF
--- a/demos/ads/protected-audience/advertiser.html.tpl
+++ b/demos/ads/protected-audience/advertiser.html.tpl
@@ -21,24 +21,27 @@
         </div>
       </div>
       <div class="row">
-        <div class="twelve column">
+        <div class="twelve column" style="display: flex; flex-direction: column; gap: 30px">
           <h4>Join Ad Interest Groups</h4>
         </div>
         <div class="row">
-          <select id="interests-select" multiple style="margin-bottom: 6px; width: 400px; height: 100px;">
+          <select id="interests-select" multiple style="width: 400px; height: 100px;">
             <option value="luxury">Luxury</option>
             <option value="travel">Travel</option>
             <option value="fashion">Fashion</option>
           </select>
         </div>
         <div class="row">
-          <button onclick="saveInterests()">Save interests</button>
-        </div>
+          <div id="status"></div>
         </div>
         <div class="row">
-          <div class="twelve column">
-            <button onclick="joinAdInterestGroups()">Join Ad Interest Groups</button>
-          </div>
+          <button onclick="saveInterests()">Save interests</button>
+          <button onclick="joinAdInterestGroups()">Join Ad Interest Groups</button>
+        </div>
+        <div class="row">
+          <a href="publisher.html">Publisher</a> |
+          <a href="publisher-prebid.html">Publisher using Prebid</a> |
+          <a href="publisher-gam.html">Publisher using GAM</a>
         </div>
       </div>
     </div>
@@ -49,21 +52,25 @@
 
 
       function saveInterests() {
+        const statusDiv = document.getElementById("status");
+        statusDiv.innerHTML = "Saving interests...";
         const interests = Array.from(document.getElementById("interests-select").selectedOptions)
           .map((option) => option.value);
 
         optable.cmd.push(() => {
           optable.instance.profile({ interests: interests.join(",") })
-            .then(() => { alert("Interests successfully saved."); })
-            .catch(() => { alert("An error occurred while saving interests."); })
+            .then(() => { statusDiv.innerHTML = "Interests successfully saved." })
+            .catch(() => { statusDiv.innerHTML = "An error occurred while saving interests." })
         })
       }
 
       function joinAdInterestGroups() {
+        const statusDiv = document.getElementById("status");
+        statusDiv.innerHTML = "Joining interest groups...";
         optable.cmd.push(() => {
           optable.instance.joinAdInterestGroups()
-            .then(() => { alert("Interest groups successfully joined."); })
-            .catch(() => { alert("An error occurred while joining interest groups."); })
+            .then(() => { statusDiv.innerHTML = "Interest groups successfully joined." })
+            .catch(() => { statusDiv.innerHTML = "An error occurred while joining interest groups." })
         })
       }
 

--- a/demos/ads/protected-audience/publisher-gam.html.tpl
+++ b/demos/ads/protected-audience/publisher-gam.html.tpl
@@ -59,6 +59,11 @@
           });
         </script>
       </div>
+      <div class="row">
+        <a href="advertiser.html">Advertiser</a> |
+        <a href="publisher.html">Publisher</a> |
+        <a href="publisher-prebid.html">Publisher using Prebid</a>
+      </div>
     </div>
   </body>
 </html>

--- a/demos/ads/protected-audience/publisher-prebid.html.tpl
+++ b/demos/ads/protected-audience/publisher-prebid.html.tpl
@@ -26,7 +26,13 @@
       </div>
       <div id="div-ad-fledge" style="width: 300px; height: 250px; border: 1px black dotted">
       </div>
+      <div class="row">
+        <a href="advertiser.html">Advertiser</a> |
+        <a href="publisher.html">Publisher</a> |
+        <a href="publisher-gam.html">Publisher using GAM</a>
+      </div>
     </div>
+
 
     <script>
         const searchParams = new URLSearchParams(window.location.search);

--- a/demos/ads/protected-audience/publisher.html.tpl
+++ b/demos/ads/protected-audience/publisher.html.tpl
@@ -60,6 +60,11 @@
             <button onclick="runAdAuction('leaderboard')">Run Ad Auction for Leaderboard</button>
           </div>
         </div>
+        <div class="row">
+          <a href="advertiser.html">Advertiser</a> |
+          <a href="publisher-prebid.html">Publisher using Prebid</a> |
+          <a href="publisher-gam.html">Publisher using GAM</a>
+        </div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
* Navigation between advertiser and publisher(s)
* Display status from saving interests and joining interest group inline

<img width="412" alt="image" src="https://github.com/Optable/optable-web-sdk/assets/38892330/c89bb145-5d6f-4f03-817a-d2e7d5ea02f7">

<img width="412" alt="image" src="https://github.com/Optable/optable-web-sdk/assets/38892330/a5763a5c-7aef-4352-a3f1-68f567286f1a">

<img width="412" alt="image" src="https://github.com/Optable/optable-web-sdk/assets/38892330/b82669ee-3f53-4f0d-8dc0-1dac78f3c2a7">

<img width="742" alt="image" src="https://github.com/Optable/optable-web-sdk/assets/38892330/d81d2dd0-4378-444c-b7ed-0d86200d43d5">
