### PR TITLE
Allow for CORS preflight cacheability by passing passport through custom header

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,12 +4,14 @@ type OptableConfig = {
   insecure?: boolean;
   cookies?: boolean;
   initPassport?: boolean;
+  identityHeaderName?: string;
 };
 
 const DCN_DEFAULTS = {
   insecure: false,
   cookies: true,
   initPassport: true,
+  identityHeaderName: "X-Optable-Visitor",
 };
 
 function getConfig(config: OptableConfig): Required<OptableConfig> {

--- a/lib/sdk.test.js
+++ b/lib/sdk.test.js
@@ -1,5 +1,16 @@
 import OptableSDK from "./sdk";
 
+beforeEach(() => {
+  jest.spyOn(global, "fetch").mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+  );
+});
+
+afterEach(() => jest.restoreAllMocks());
+
 test("eid is correct", () => {
   const expected = "e:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3";
 
@@ -46,4 +57,41 @@ test("cid trim spaces", () => {
 
 test("cid preserve case", () => {
   expect(OptableSDK.cid("ABCD")).toEqual("c:ABCD");
+});
+
+test("passport is passed along", async () => {
+  const buildRes = (passport) => ({
+    headers: new Headers({ "Content-Type": "application/json", "X-Optable-Visitor": passport }),
+    ok: true,
+    json: () => Promise.resolve({}),
+  });
+
+  global.fetch.mockImplementationOnce(() => Promise.resolve(buildRes("one")));
+  global.fetch.mockImplementationOnce(() => Promise.resolve(buildRes("two")));
+  global.fetch.mockImplementationOnce(() => Promise.resolve(buildRes("three")));
+
+  const sdk = new OptableSDK({
+    host: "node1.cloud.test",
+    site: "test",
+    cookies: false,
+    initPassport: false,
+  });
+
+  let request;
+  await sdk.identify("c:id").catch(() => {});
+
+  request = global.fetch.mock.lastCall[0];
+  expect(request.headers.get("X-Optable-Visitor")).toBe(null);
+
+  await sdk.identify("c:id").catch(() => {});
+  request = global.fetch.mock.lastCall[0];
+  expect(request.headers.get("X-Optable-Visitor")).toBe("one");
+
+  await sdk.identify("c:id").catch(() => {});
+  request = global.fetch.mock.lastCall[0];
+  expect(request.headers.get("X-Optable-Visitor")).toBe("two");
+
+  await sdk.identify("c:id").catch(() => {});
+  request = global.fetch.mock.lastCall[0];
+  expect(request.headers.get("X-Optable-Visitor")).toBe("three");
 });


### PR DESCRIPTION
This updates the `fetch` function used for all communications with edge to no longer pass passport through querystring / expect it in response body. Since passport changes constantly (since it encode timestamps) passing it through query string prevents cacheability of CORS responses.
Instead this passes/expects it through custom request/response headers the same way ios and android SDK does it.

This however depends on updating the server CORS setup to Accept and Expose those X-Optable-Visitor headers.