### PR TITLE
Allow custom targeting id

### DIFF
--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -26,8 +26,11 @@ type TargetingResponse = {
 
 const lmpidProvider = "loblawmedia.ca";
 
-async function Targeting(config: Required<OptableConfig>): Promise<TargetingResponse> {
-  const response: TargetingResponse = await fetch("/v2/targeting", config, {
+async function Targeting(config: Required<OptableConfig>, id: string): Promise<TargetingResponse> {
+  const searchParams = new URLSearchParams({ id });
+  const path = "/v2/targeting?" + searchParams.toString();
+
+  const response: TargetingResponse = await fetch(path, config, {
     method: "GET",
     headers: { Accept: "application/json" },
   });

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -45,9 +45,9 @@ class OptableSDK {
     return Uid2Token(this.dcn, id);
   }
 
-  async targeting(): Promise<TargetingResponse> {
+  async targeting(id: string = "__passport__"): Promise<TargetingResponse> {
     await this.init;
-    return Targeting(this.dcn);
+    return Targeting(this.dcn, id);
   }
 
   targetingFromCache(): TargetingResponse | null {


### PR DESCRIPTION
This allows passing a custom identifier to resolve targeting/. This is an experimental feature and will impact cached targeting response in browser's localStorage, last-call-wins.