### PR TITLE
Fix custom targeting ID

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/setup-jest.js"],
 };
 
 module.exports = config;

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -1,0 +1,12 @@
+import { buildRequest } from "./network";
+import { default as buildInfo } from "../build.json";
+
+describe("buildRequest", () => {
+  test("preserves path query string", () => {
+    const dcn = { cookies: true, host: "host", insecure: false, site: "site" };
+    const req = { method: "GET" };
+    const request = buildRequest("/path?query=string", dcn, req);
+
+    expect(request.url).toBe(`https://host/site/path?query=string&osdk=web-${buildInfo.version}&cookies=yes`);
+  });
+});

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -7,20 +7,15 @@ function buildRequest(path: string, config: Required<OptableConfig>, init?: Requ
 
   const proto = insecure ? "http" : "https";
   const url = new URL(`${site}${path}`, `${proto}://${host}`);
+  url.searchParams.set("osdk", `web-${buildInfo.version}`);
 
   if (cookies) {
-    url.search = new URLSearchParams({
-      cookies: "yes",
-      osdk: `web-${buildInfo.version}`,
-    }).toString();
+    url.searchParams.set("cookies", "yes");
   } else {
     const ls = new LocalStorage(config);
     const pass = ls.getPassport();
-    url.search = new URLSearchParams({
-      cookies: "no",
-      passport: pass ? pass : "",
-      osdk: `web-${buildInfo.version}`,
-    }).toString();
+    url.searchParams.set("cookies", "no");
+    url.searchParams.set("pass", pass ? pass : "");
   }
 
   const requestInit: RequestInit = { ...init };
@@ -56,5 +51,5 @@ async function fetch<T>(path: string, config: Required<OptableConfig>, init?: Re
   return data;
 }
 
-export { fetch };
+export { fetch, buildRequest };
 export default fetch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "typescript": "^5.2.2",
         "webpack": "^5.76.0",
-        "webpack-cli": "^4.7.2"
+        "webpack-cli": "^4.7.2",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9012,6 +9013,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -16288,6 +16295,12 @@
       "requires": {
         "iconv-lite": "0.6.3"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "typescript": "^5.2.2",
     "webpack": "^5.76.0",
-    "webpack-cli": "^4.7.2"
+    "webpack-cli": "^4.7.2",
+    "whatwg-fetch": "^3.6.20"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,0 +1,1 @@
+import "whatwg-fetch";


### PR DESCRIPTION
Custom targeting ID would always be overriden by our buildRequest default query string.
This makes sure buildRequest only appends parameters instead of rewritting query string.