### PR TITLE
Make tagging pattern matching more strict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release new version of Optable SDK and demos
 on:
   push:
     tags:
-      - "v.*"
+      - "v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?"
 
 env:
   gcp-project-id: 118585658141


### PR DESCRIPTION
This PR improves the tagging pattern for releases, this pattern will match with
- v1.2.3
- v1.2.3-whatever
- v13.123.123345