### PR TITLE
Bump to latest js-sha256

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "js-sha256": "^0.9.0",
+        "js-sha256": "^0.11.0",
         "regenerator-runtime": "^0.13.7"
       },
       "devDependencies": {
@@ -7874,9 +7874,10 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
+      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -16193,9 +16194,9 @@
       }
     },
     "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
+      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "js-sha256": "^0.9.0",
+    "js-sha256": "^0.11.0",
     "regenerator-runtime": "^0.13.7"
   },
   "files": [


### PR DESCRIPTION
Various bugs were fixed that could lead to invalid sha256 in browser env eg https://github.com/emn178/js-sha256/issues/43

Better alternative would be to move to native Crypto.subtle however it exposes an async interface which doesn't fit our usecase (this is used exclusively for `OptableSDK.eid(email: string): string {` helper)
