### PR TITLE
Drop insecure flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ deps:
 export SDK_URI ?= https://localhost:8181/sdk.js
 export DCN_HOST ?= sandbox.optable.co
 export DCN_SITE ?= web-sdk-demo
-export DCN_INSECURE ?= false
 export DCN_INIT ?= true
 export DCN_ID ?= optable
 export ADS_HOST ?= ads.optable.co
@@ -38,7 +37,6 @@ DEMO_VARS:='\
 	DCN_HOST=$${DCN_HOST} \
 	DCN_SITE=$${DCN_SITE} \
 	DCN_ID=$${DCN_ID} \
-	DCN_INSECURE=$${DCN_INSECURE} \
 	DCN_INIT=$${DCN_INIT} \
 	ADS_SITE=$${ADS_SITE} \
 	ADS_HOST=$${ADS_HOST} \

--- a/README.md
+++ b/README.md
@@ -103,13 +103,7 @@ const sdk = new OptableSDK({ host: "dcn.customer.com", site: "my-site" });
 
 You can then call various SDK APIs on the instance as shown in the examples below. It's also possible to configure multiple instances of `OptableSDK` in order to connect to other (e.g., partner) DCNs and/or reference other configured web site slug IDs.
 
-Note that all SDK communication with Optable DCNs is done over TLS. The only exception to this is if you instantiate the `OptableSDK` class with the `insecure` optional boolean parameter set to `true`. For example:
-
-```js
-const sdk = new OptableSDK({ host: "dcn.customer.com", site: "my-site", insecure: true });
-```
-
-Note that production DCNs only listen to TLS traffic. The `insecure: true` option is meant to be used by Optable developers running the DCN locally for testing. See [developer docs](https://github.com/Optable/optable-web-sdk/tree/master/docs) for other developer notes.
+Note that all SDK communication with Optable DCNs is done over TLS.
 
 ### Identify API
 

--- a/demos/ads/protected-audience/advertiser.html.tpl
+++ b/demos/ads/protected-audience/advertiser.html.tpl
@@ -79,7 +79,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: cookiesTransport,
         });
       })

--- a/demos/ads/protected-audience/publisher-gam.html.tpl
+++ b/demos/ads/protected-audience/publisher-gam.html.tpl
@@ -23,7 +23,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: cookiesTransport,
         });
       })

--- a/demos/ads/protected-audience/publisher.html.tpl
+++ b/demos/ads/protected-audience/publisher.html.tpl
@@ -26,7 +26,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: cookiesTransport,
         });
       })

--- a/demos/ads/topics/publisher.html.tpl
+++ b/demos/ads/topics/publisher.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: cookiesTransport,
         });
       })

--- a/demos/react/webpack.config.js
+++ b/demos/react/webpack.config.js
@@ -29,7 +29,6 @@ module.exports = {
         host: process.env.DCN_HOST,
         initPassport: process.env.DCN_INIT === "true",
         site: "${DCN_SITE}",
-        insecure: process.env.DCN_INSECURE === "true",
       }),
     }),
     new HtmlWebpackPlugin({

--- a/demos/vanilla/identify.html.tpl
+++ b/demos/vanilla/identify.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/identify.html.tpl
+++ b/demos/vanilla/nocookies/identify.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/nocookies/profile.html.tpl
+++ b/demos/vanilla/nocookies/profile.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/nocookies/targeting/gam360.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/nocookies/targeting/prebid.html.tpl
+++ b/demos/vanilla/nocookies/targeting/prebid.html.tpl
@@ -26,7 +26,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/nocookies/witness.html.tpl
+++ b/demos/vanilla/nocookies/witness.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
           cookies: false,
         });
 

--- a/demos/vanilla/profile.html.tpl
+++ b/demos/vanilla/profile.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/targeting/gam360-cached.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/gam360.html.tpl
+++ b/demos/vanilla/targeting/gam360.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/prebid.html.tpl
+++ b/demos/vanilla/targeting/prebid.html.tpl
@@ -26,7 +26,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/uid2_token/login.html.tpl
+++ b/demos/vanilla/uid2_token/login.html.tpl
@@ -22,7 +22,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/witness.html.tpl
+++ b/demos/vanilla/witness.html.tpl
@@ -20,7 +20,6 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
-          insecure: JSON.parse("${DCN_INSECURE}"),
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,13 +1,11 @@
 type OptableConfig = {
   host: string;
   site: string;
-  insecure?: boolean;
   cookies?: boolean;
   initPassport?: boolean;
 };
 
 const DCN_DEFAULTS = {
-  insecure: false,
   cookies: true,
   initPassport: true,
 };

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -3,7 +3,7 @@ import { default as buildInfo } from "../build.json";
 
 describe("buildRequest", () => {
   test("preserves path query string", () => {
-    const dcn = { cookies: true, host: "host", insecure: false, site: "site" };
+    const dcn = { cookies: true, host: "host", site: "site" };
     const req = { method: "GET" };
     const request = buildRequest("/path?query=string", dcn, req);
 

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -3,10 +3,9 @@ import { default as buildInfo } from "../build.json";
 import { LocalStorage } from "./storage";
 
 function buildRequest(path: string, config: Required<OptableConfig>, init?: RequestInit): Request {
-  const { site, host, insecure, cookies } = config;
+  const { site, host, cookies } = config;
 
-  const proto = insecure ? "http" : "https";
-  const url = new URL(`${site}${path}`, `${proto}://${host}`);
+  const url = new URL(`${site}${path}`, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
 
   if (cookies) {


### PR DESCRIPTION
We have updated our local setup to run demos using https for some time now.
There is no reason to keep the insecure flag around anymore.