### PR TITLE
ci: wrong artifact name was used when downloading the lib

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Download lib artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist-web
+          name: dist-lib
           path: lib/dist
 
         # Step will fail if the version is invalid, github.ref_name is the tag name (v.*.*.*)


### PR DESCRIPTION
The wrong artifact name was provided.