### PR TITLE
ci: remove quotes from custom header

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,9 @@ jobs:
           path: "browser/dist/sdk.js"
           destination: "optable-web-sdk/${{ matrix.sdk-version }}"
           gzip: false
+          process_gcloudignore: false
           headers: |
-            x-goog-meta-optable-sdk-version: '${{ github.ref_name }}'
+            x-goog-meta-optable-sdk-version: ${{ github.ref_name }}
 
   deploy-demo:
     needs: [deploy-sdk-to-npm]


### PR DESCRIPTION
Quotes were added because of the documentation but the result is different for the header: 

![image](https://github.com/user-attachments/assets/9010f843-382e-4789-b2e7-ab5e9ff2112b)

```
[headers](https://github.com/google-github-actions/upload-cloud-storage#user-content-headers): (Optional) Set object metadata. For example, to set the Content-Type header to application/json and custom metadata with key custom-field and value custom-value:

headers: |-
  content-type: 'application/json'
  x-goog-meta-custom-field: 'custom-value'
Settable fields are: cache-control, content-disposition, content-encoding, content-language, content-type, custom-time. See [the document](https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata#settable-fields;-field-values) for details. All custom metadata fields must be prefixed with x-goog-meta-.
```

Also adding flag:
`process_gcloudignore: false`

This will remove the warning:
<img width="1387" alt="image" src="https://github.com/user-attachments/assets/9c2cac7f-a4a6-40e5-941f-6816371466df">
