### PR TITLE
Update dependencies, readme and refactor npm setup

### DIFF
--- a/.github/actions/setup-npm-demos-npm/action.yml
+++ b/.github/actions/setup-npm-demos-npm/action.yml
@@ -1,0 +1,24 @@
+name: "Setup demo npm"
+description: "A composite action to setup npm for npm demo"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Node.js version
+      id: get-node-version
+      shell: bash
+      run: echo "node_version=$(grep node .tool-versions | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.get-node-version.outputs.node_version }}
+    - name: npm cache
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: demos/npm/node_modules
+        key: ${{ runner.os }}-npm-packages-npm-demo-${{ hashFiles('demos/npm/package-lock.json') }}
+    - name: Install dependencies
+      shell: bash
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci --prefix demos/npm

--- a/.github/actions/setup-npm-demos-react/action.yml
+++ b/.github/actions/setup-npm-demos-react/action.yml
@@ -1,0 +1,24 @@
+name: "Setup react demo npm"
+description: "A composite action to setup npm for react demo"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Node.js version
+      id: get-node-version
+      shell: bash
+      run: echo "node_version=$(grep node .tool-versions | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.get-node-version.outputs.node_version }}
+    - name: npm cache
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: demos/react/node_modules
+        key: ${{ runner.os }}-npm-packages-react-demo-${{ hashFiles('demos/react/package-lock.json') }}
+    - name: Install dependencies
+      shell: bash
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci --prefix demos/react

--- a/.github/actions/setup-npm/action.yml
+++ b/.github/actions/setup-npm/action.yml
@@ -1,0 +1,24 @@
+name: "Setup npm"
+description: "A composite action to setup npm"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Node.js version
+      id: get-node-version
+      shell: bash
+      run: echo "node_version=$(grep node .tool-versions | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.get-node-version.outputs.node_version }}
+    - name: npm cache
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-npm-packages-${{ hashFiles('package-lock.json') }}
+    - name: Install dependencies
+      shell: bash
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,16 +19,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm
+        uses: ./.github/actions/setup-npm
 
       - name: Build web production
         run: npm run build-web -- --mode=production
@@ -45,16 +37,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm
+        uses: ./.github/actions/setup-npm
 
       - name: Patch build.json version
         run: ./scripts/patch-version.sh "${{ inputs.version }}"
@@ -111,30 +95,12 @@ jobs:
           name: dist-lib
           path: lib/dist
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
-
       # SDK has a dependency on third-party js-sha256, we need to install node_modules in the root directory
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: |
-          cd ../../
-          npm ci
+      - name: Setup npm
+        uses: ./.github/actions/setup-npm
 
-      - name: Cache react demo dependencies
-        id: cache-node-modules-react-demo
-        uses: actions/cache@v4
-        with:
-          path: demos/react/node_modules
-          key: node-react-demo-${{ hashFiles('demos/react/package-lock.json') }}
-
-      - name: Install react demo dependencies
-        if: steps.cache-node-modules-react-demo.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm react demo
+        uses: ./.github/actions/setup-npm-demos-react
 
       - name: Build react demo
         run: npm run build
@@ -154,16 +120,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache npm-demo dependencies
-        id: cache-node-modules-npm-demo
-        uses: actions/cache@v4
-        with:
-          path: demos/npm/node_modules
-          key: node-npm-demo-${{ hashFiles('demos/npm/package-lock.json') }}
-
-      - name: Install npm-demo dependencies
-        if: steps.cache-node-modules-npm-demo.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm demos npm
+        uses: ./.github/actions/setup-npm-demos-npm
 
       - name: Build npm-demo
         run: npm run build

--- a/.github/workflows/reusable-lint-test.yml
+++ b/.github/workflows/reusable-lint-test.yml
@@ -8,16 +8,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm
+        uses: ./.github/actions/setup-npm
 
       - name: Test
         run: npm run test
@@ -28,16 +20,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+      - name: Setup npm
+        uses: ./.github/actions/setup-npm
 
       - name: Run prettier
         run: npm run format

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 16.17.0
+nodejs 22.12.0
 semver 3.3.0
 mkcert 1.4.4
-pre-commit 3.6.2
+pre-commit 4.0.1

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -9,10 +9,10 @@ You can also develop it natively by installing Node and NPM on your machine.
 
 `docker-compose up` will build and start both the SDK standalone docker container and a separate container with several web SDK demos.
 
-Once started via docker-compose, you can access the demos by browsing to `http://localhost:8180/`.
+Once started via docker-compose, you can access the demos by browsing to `https://localhost:8180/`.
 (Re)-Building of browser bundle, sdk and demos is done locally using `make`.
 
-The latest SDK standalone bundle build will be accessible from `http://localhost:8181/sdk.js`
+The latest SDK standalone bundle build will be accessible from `https://localhost:8181/sdk.js`
 
 The demos and SDK running via `docker-compose` will by default communicate with an Optable Sandbox "edge" running on `https://node1.cloud.test/`
 


### PR DESCRIPTION
There are some discrepancies of the dependencies between optable-sandbox and optable-web-sdk. Also, the node version is outdated and not using the same node version in the CI as the local version can be problematic.

This PR updates:
- dependency => node to use LTS (22.12.0)
- dependency => pre-commit to 4.0.1
- refactors the npm setup to use the specified version of node
- updates the readme to use https

QA: Automatically QAed, all checks passed below. The Release workflow doesn't need to setup npm.