### PR TITLE
Ignore dist/ when running tsc

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -9,5 +9,5 @@
     "lib": ["DOM", "DOM.Iterable", "ES6"]
   },
   "include": ["./build.json", "."],
-  "exclude": ["./**/*.test.ts", "./test"]
+  "exclude": ["./**/*.test.ts", "./test", "./dist"]
 }


### PR DESCRIPTION
Fix a regression introduced in build 
```
error TS5055: Cannot write file '.../optable-web-sdk/lib/dist/addons/gpt.d.ts' because it would overwrite input file.
```