### PR TITLE
Use safe navigation for objects when reading tcf purpose

### DIFF
--- a/lib/core/regs/consent.ts
+++ b/lib/core/regs/consent.ts
@@ -97,9 +97,9 @@ function tcfPurpose(data: tcf.cmpapi.TCData, purpose: number, vendorID?: number)
   }
 
   if (vendorID) {
-    return data.purpose.consents[purpose] && data.vendor.consents[vendorID];
+    return !!data.purpose?.consents?.[purpose] && !!data.vendor?.consents?.[vendorID];
   }
-  return !!data.publisher.consents[purpose];
+  return !!data.publisher?.consents?.[purpose];
 }
 
 function gppCanPurpose(data: gpp.cmpapi.PingReturn, purpose: number, vendorID?: number): boolean {

--- a/lib/core/regs/tcf/cmpapi.ts
+++ b/lib/core/regs/tcf/cmpapi.ts
@@ -17,41 +17,41 @@ type TCData = {
   useNonStandardStacks: boolean;
   publisherCC: string;
   purposeOneTreatment: boolean;
-  purpose: {
-    consents: {
+  purpose?: {
+    consents?: {
       [purposeID: string]: boolean;
     };
-    legitimateInterests: {
+    legitimateInterests?: {
       [purposeID: string]: boolean;
     };
   };
-  vendor: {
-    consents: {
+  vendor?: {
+    consents?: {
       [vendorID: string]: boolean;
     };
-    legitimateInterests: {
+    legitimateInterests?: {
       [vendorID: string]: boolean;
     };
   };
   specialFeatureOptins: {
     [featureID: string]: boolean;
   };
-  publisher: {
-    consents: {
+  publisher?: {
+    consents?: {
       [purposeID: string]: boolean;
     };
-    legitimateInterests: {
+    legitimateInterests?: {
       [purposeID: string]: boolean;
     };
-    customPurpose: {
-      consents: {
+    customPurpose?: {
+      consents?: {
         [purposeID: string]: boolean;
       };
-      legitimateInterests: {
+      legitimateInterests?: {
         [purposeID: string]: boolean;
       };
     };
-    restrictions: {
+    restrictions?: {
       [purposeID: string]: {
         [vendorID: string]: 0 | 1 | 2;
       };


### PR DESCRIPTION
Defensively navigate tcdata nested structure as not all CMP are implementing it fully.

https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata isn't very clear about the presence of `publisher` consent and we've seen instances of undefined access in production.

To avoid crashing execution when this happens, this PR updates nested objects type definition of TCData to be optional.