### PR TITLE
consent handling: Refactor and various fixes

### DIFF
--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -20,7 +20,6 @@ describe("buildRequest", () => {
     expect([...url.searchParams.entries()]).toEqual([
       ["query", "string"],
       ["osdk", `web-${buildInfo.version}`],
-      ["reg", "can"],
       ["gpp", "gpp"],
       ["gpp_sid", "1,2"],
       ["cookies", "yes"],

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -8,20 +8,20 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   const url = new URL(`${site}${path}`, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
 
-  if (config.consent.reg) {
-    url.searchParams.set("reg", config.consent.reg);
-  }
-
-  if (config.consent.gpp) {
+  if (typeof config.consent.gpp !== "undefined") {
     url.searchParams.set("gpp", config.consent.gpp);
   }
 
-  if (config.consent.gppSectionIDs) {
+  if (typeof config.consent.gppSectionIDs !== "undefined") {
     url.searchParams.set("gpp_sid", config.consent.gppSectionIDs.join(","));
   }
 
-  if (config.consent.tcf) {
-    url.searchParams.set("tcf", config.consent.tcf);
+  if (typeof config.consent.gdpr !== "undefined") {
+    url.searchParams.set("gdpr_consent", config.consent.gdpr);
+  }
+
+  if (typeof config.consent.gdprApplies !== "undefined") {
+    url.searchParams.set("gdpr", Number(config.consent.gdprApplies).toString());
   }
 
   if (cookies) {

--- a/lib/core/regs/consent.test.js
+++ b/lib/core/regs/consent.test.js
@@ -50,6 +50,28 @@ describe("applicableReg", () => {
     expect(applicableReg("us", { gppSectionIDs: [-1] })).toBe(null);
   });
 
+  it("prefers tcf signaling over gpp", () => {
+    expect(applicableReg("gdpr", { gdprApplies: true, gppSectionIDs: [8] })).toBe("gdpr");
+    expect(applicableReg("can", { gdprApplies: true, gppSectionIDs: [5] })).toBe("gdpr");
+    expect(applicableReg("us", { gdprApplies: true, gppSectionIDs: [-1] })).toBe("gdpr");
+    expect(applicableReg("gdpr", { gdprApplies: false, gppSectionIDs: [8] })).toBe(null);
+    expect(applicableReg("can", { gdprApplies: false, gppSectionIDs: [5] })).toBe("can");
+    expect(applicableReg("us", { gdprApplies: false, gppSectionIDs: [-1] })).toBe("us");
+
+    // presence of gdprData may resolve to gdpr only if it was detected as well
+    expect(applicableReg("gdpr", { gdprData: {} })).toBe("gdpr");
+    expect(applicableReg(null, { gdprData: {} })).toBe(null);
+    expect(applicableReg("can", { gdprData: {} })).toBe("can");
+  });
+
+  it("infers gdpr>can>us when using gpp", () => {
+    expect(applicableReg(null, { gppSectionIDs: [2, 5, 7, 8] })).toBe("gdpr");
+    expect(applicableReg(null, { gppSectionIDs: [5, 7, 8] })).toBe("can");
+    expect(applicableReg(null, { gppSectionIDs: [7, 8] })).toBe("us");
+    expect(applicableReg(null, { gppSectionIDs: [8] })).toBe("us");
+    expect(applicableReg(null, { gppSectionIDs: [] })).toBe(null);
+  });
+
   it("returns reg until cmp knows", () => {
     expect(applicableReg("gdpr", {})).toBe("gdpr");
     expect(applicableReg("gdpr", { gppSectionIDs: [0] })).toBe("gdpr");

--- a/lib/core/regs/consent.test.js
+++ b/lib/core/regs/consent.test.js
@@ -1,4 +1,4 @@
-import { getConsent } from "./consent";
+import { getConsent, applicableReg } from "./consent";
 import * as gpp from "./gpp";
 
 const allowAll = {
@@ -14,6 +14,53 @@ const denyAll = {
   useProfilesForAdvertising: false,
   measureAdvertisingPerformance: false,
 };
+
+describe("applicableReg", () => {
+  it("returns gdpr when cmp indicates gdpr applies", () => {
+    expect(applicableReg("can", { gdprApplies: true })).toBe("gdpr");
+    expect(applicableReg("us", { gdprApplies: true })).toBe("gdpr");
+    expect(applicableReg(null, { gdprApplies: true })).toBe("gdpr");
+
+    expect(applicableReg("can", { gppSectionIDs: [2] })).toBe("gdpr");
+    expect(applicableReg("us", { gppSectionIDs: [2] })).toBe("gdpr");
+    expect(applicableReg(null, { gppSectionIDs: [2] })).toBe("gdpr");
+  });
+
+  it("returns can when cmp indicates can applies", () => {
+    expect(applicableReg("gdpr", { gppSectionIDs: [5] })).toBe("can");
+    expect(applicableReg("us", { gppSectionIDs: [5] })).toBe("can");
+    expect(applicableReg(null, { gppSectionIDs: [5] })).toBe("can");
+  });
+
+  it("returns us when cmp indicates us applies", () => {
+    expect(applicableReg("gdpr", { gppSectionIDs: [7] })).toBe("us");
+    expect(applicableReg("can", { gppSectionIDs: [7] })).toBe("us");
+    expect(applicableReg(null, { gppSectionIDs: [7] })).toBe("us");
+  });
+
+  it("returns unknown when cmp indicates detected regulation does not apply", () => {
+    expect(applicableReg("gdpr", { gdprApplies: false })).toBe(null);
+    expect(applicableReg("gdpr", { gppSectionIDs: [999] })).toBe(null);
+    expect(applicableReg("gdpr", { gppSectionIDs: [-1] })).toBe(null);
+
+    expect(applicableReg("can", { gppSectionIDs: [999] })).toBe(null);
+    expect(applicableReg("can", { gppSectionIDs: [-1] })).toBe(null);
+
+    expect(applicableReg("us", { gppSectionIDs: [999] })).toBe(null);
+    expect(applicableReg("us", { gppSectionIDs: [-1] })).toBe(null);
+  });
+
+  it("returns reg until cmp knows", () => {
+    expect(applicableReg("gdpr", {})).toBe("gdpr");
+    expect(applicableReg("gdpr", { gppSectionIDs: [0] })).toBe("gdpr");
+
+    expect(applicableReg("can", {})).toBe("can");
+    expect(applicableReg("can", { gppSectionIDs: [0] })).toBe("can");
+
+    expect(applicableReg("us", {})).toBe("us");
+    expect(applicableReg("us", { gppSectionIDs: [0] })).toBe("us");
+  });
+});
 
 describe("getConsent", () => {
   afterEach(() => {
@@ -64,7 +111,7 @@ describe("getConsent", () => {
     // Simulate event indicating that gdpr doesn't apply
     signal(tcfData({ gdprApplies: false, tcString: "doesntapply" }));
     expect(consent.deviceAccess).toBe(true);
-    expect(consent.tcf).toBeUndefined();
+    expect(consent.gdpr).toBe("doesntapply");
 
     // Simulate event where no consent is granted
     signal(
@@ -74,7 +121,7 @@ describe("getConsent", () => {
       })
     );
     expect(consent.deviceAccess).toBe(false);
-    expect(consent.tcf).toBe("noconsent");
+    expect(consent.gdpr).toBe("noconsent");
 
     // Simulate event where purpose 1 consent is granted to the publisher
     signal(
@@ -84,7 +131,7 @@ describe("getConsent", () => {
       })
     );
     expect(consent.deviceAccess).toBe(true);
-    expect(consent.tcf).toBe("purpose1");
+    expect(consent.gdpr).toBe("purpose1");
 
     // Simulate removing consent
     signal(
@@ -94,7 +141,7 @@ describe("getConsent", () => {
       })
     );
     expect(consent.deviceAccess).toBe(false);
-    expect(consent.tcf).toBe("revoked");
+    expect(consent.gdpr).toBe("revoked");
   });
 
   it("updates consent based on gpp signals for gdpr", () => {
@@ -105,11 +152,11 @@ describe("getConsent", () => {
     expect(consent.deviceAccess).toBe(false);
     expect(consent.reg).toBe("gdpr");
 
-    // Simulate gpp ready event indicating no applicable sections
-    signal({ applicableSections: [-1], gppString: "ignored" });
-    expect(consent.deviceAccess).toBe(true);
+    // Simulate gpp ready event indicating applicable sections unknown
+    signal({ applicableSections: [0], gppString: "ignored" });
+    expect(consent.deviceAccess).toBe(false);
     expect(consent.gpp).toBe("ignored");
-    expect(consent.gppSectionIDs).toEqual([-1]);
+    expect(consent.gppSectionIDs).toEqual([0]);
 
     // Section tcfeuv2 applies but nothing in parsed sections
     signal({ parsedSections: {}, applicableSections: [gpp.tcfeuv2.SectionID], gppString: "noparsedsections" });
@@ -247,7 +294,7 @@ describe("getConsent", () => {
     );
 
     expect(consent.deviceAccess).toBe(true);
-    expect(consent.tcf).toBe("granted");
+    expect(consent.gdpr).toBe("granted");
     expect(consent.gpp).toBe("revoked");
   });
 

--- a/lib/core/regs/consent.ts
+++ b/lib/core/regs/consent.ts
@@ -28,57 +28,115 @@ type Consent = {
 
   // The regulation that was detected, null if unknown
   reg: Regulation | null;
-  // The TCF string if available
-  tcf?: string;
+
+  // The GDPR string if available
+  gdpr?: string;
+
+  // Whether GDPR applies to the visitor
+  gdprApplies?: boolean;
+
   // The GPP string if available
   gpp?: string;
+
   // The GPP section IDs that are applicable
   gppSectionIDs?: number[];
 };
 
-function getConsent(reg: Regulation | null, conf: CMPApiConfig = {}): Consent {
+type CMPSignals = {
+  gdprString?: string;
+  gdprApplies?: boolean;
+  gdprData?: tcf.cmpapi.TCData;
+
+  gppString?: string;
+  gppSectionIDs?: number[];
+  gppData?: gpp.cmpapi.PingReturn;
+};
+
+function applicableReg(defaultReg: Regulation | null, cmp: CMPSignals): Regulation | null {
+  const { gdprApplies, gppSectionIDs } = cmp;
+
+  // Respect CMP signaling that a regulation applies
+  if (gdprApplies === true) {
+    return "gdpr";
+  }
+
+  if (gpp.euSections.some((s) => gppSectionIDs?.includes(s.SectionID))) {
+    return "gdpr";
+  }
+
+  if (gpp.caSections.some((s) => gppSectionIDs?.includes(s.SectionID))) {
+    return "can";
+  }
+
+  if (gpp.usSections.some((s) => gppSectionIDs?.includes(s.SectionID))) {
+    return "us";
+  }
+
+  const gppUnknown = typeof gppSectionIDs === "undefined" || (gppSectionIDs.length === 1 && gppSectionIDs[0] === 0);
+
+  // Override with unknown regulation if CMP indicates the detected
+  // regulation doesn't apply
+  switch (defaultReg) {
+    case "gdpr":
+      if (gdprApplies === false) {
+        return null;
+      }
+      if (!gppUnknown && !gpp.euSections.some((s) => gppSectionIDs!.includes(s.SectionID))) {
+        return null;
+      }
+      break;
+    case "can":
+      if (!gppUnknown && !gpp.caSections.some((s) => gppSectionIDs!.includes(s.SectionID))) {
+        return null;
+      }
+      break;
+    case "us":
+      if (!gppUnknown && !gpp.usSections.some((s) => gppSectionIDs!.includes(s.SectionID))) {
+        return null;
+      }
+      break;
+  }
+
+  return defaultReg;
+}
+
+function computeConsent(defaultReg: Regulation | null, cmp: CMPSignals, conf: CMPApiConfig = {}): Consent {
+  const reg = applicableReg(defaultReg, cmp);
+
   const consent: Consent = {
     reg,
+    gpp: cmp.gppString,
+    gppSectionIDs: cmp.gppSectionIDs,
+    gdpr: cmp.gdprString,
+    gdprApplies: cmp.gdprApplies,
+
     deviceAccess: false,
     createProfilesForAdvertising: false,
     useProfilesForAdvertising: false,
     measureAdvertisingPerformance: false,
   };
 
-  onGPPChange((data) => {
-    consent.gpp = data.gppString;
-    consent.gppSectionIDs = data.applicableSections;
-  });
-
-  onTCFChange((data) => {
-    consent.tcf = data.gdprApplies ? data.tcString : undefined;
-  });
-
   switch (reg) {
     case "gdpr":
-      if (hasTCF()) {
-        onTCFChange((data) => {
-          consent.deviceAccess = tcfPurpose(data, 1, conf.tcfeuVendorID);
-          consent.createProfilesForAdvertising = tcfPurpose(data, 3, conf.tcfeuVendorID);
-          consent.useProfilesForAdvertising = tcfPurpose(data, 4, conf.tcfeuVendorID);
-          consent.measureAdvertisingPerformance = tcfPurpose(data, 7, conf.tcfeuVendorID);
-        });
-      } else if (hasGPP()) {
-        onGPPChange((data) => {
-          consent.deviceAccess = gppEuPurpose(data, 1, conf.tcfeuVendorID);
-          consent.createProfilesForAdvertising = gppEuPurpose(data, 3, conf.tcfeuVendorID);
-          consent.useProfilesForAdvertising = gppEuPurpose(data, 4, conf.tcfeuVendorID);
-          consent.measureAdvertisingPerformance = gppEuPurpose(data, 7, conf.tcfeuVendorID);
-        });
+      if (cmp.gdprData) {
+        consent.deviceAccess = tcfPurpose(cmp.gdprData, 1, conf.tcfeuVendorID);
+        consent.createProfilesForAdvertising = tcfPurpose(cmp.gdprData, 3, conf.tcfeuVendorID);
+        consent.useProfilesForAdvertising = tcfPurpose(cmp.gdprData, 4, conf.tcfeuVendorID);
+        consent.measureAdvertisingPerformance = tcfPurpose(cmp.gdprData, 7, conf.tcfeuVendorID);
+      } else if (cmp.gppData) {
+        consent.deviceAccess = gppEuPurpose(cmp.gppData, 1, conf.tcfeuVendorID);
+        consent.createProfilesForAdvertising = gppEuPurpose(cmp.gppData, 3, conf.tcfeuVendorID);
+        consent.useProfilesForAdvertising = gppEuPurpose(cmp.gppData, 4, conf.tcfeuVendorID);
+        consent.measureAdvertisingPerformance = gppEuPurpose(cmp.gppData, 7, conf.tcfeuVendorID);
       }
       break;
     case "can":
       consent.deviceAccess = true;
-      onGPPChange((data) => {
-        consent.createProfilesForAdvertising = gppCanPurpose(data, 3, conf.tcfcaVendorID);
-        consent.useProfilesForAdvertising = gppCanPurpose(data, 4, conf.tcfcaVendorID);
-        consent.measureAdvertisingPerformance = gppCanPurpose(data, 7, conf.tcfcaVendorID);
-      });
+      if (cmp.gppData) {
+        consent.createProfilesForAdvertising = gppCanPurpose(cmp.gppData, 3, conf.tcfcaVendorID);
+        consent.useProfilesForAdvertising = gppCanPurpose(cmp.gppData, 4, conf.tcfcaVendorID);
+        consent.measureAdvertisingPerformance = gppCanPurpose(cmp.gppData, 7, conf.tcfcaVendorID);
+      }
       break;
     case "us":
     default:
@@ -91,11 +149,28 @@ function getConsent(reg: Regulation | null, conf: CMPApiConfig = {}): Consent {
   return consent;
 }
 
-function tcfPurpose(data: tcf.cmpapi.TCData, purpose: number, vendorID?: number): boolean {
-  if (!data.gdprApplies) {
-    return true;
-  }
+function getConsent(defaultReg: Regulation | null, conf: CMPApiConfig = {}): Consent {
+  const cmp: CMPSignals = {};
+  const consent = computeConsent(defaultReg, cmp, conf);
 
+  onTCFChange((data) => {
+    cmp.gdprString = data.tcString;
+    cmp.gdprApplies = data.gdprApplies;
+    cmp.gdprData = data;
+    Object.assign(consent, computeConsent(defaultReg, cmp, conf));
+  });
+
+  onGPPChange((data) => {
+    cmp.gppString = data.gppString;
+    cmp.gppSectionIDs = data.applicableSections;
+    cmp.gppData = data;
+    Object.assign(consent, computeConsent(defaultReg, cmp, conf));
+  });
+
+  return consent;
+}
+
+function tcfPurpose(data: tcf.cmpapi.TCData, purpose: number, vendorID?: number): boolean {
   if (vendorID) {
     return !!data.purpose?.consents?.[purpose] && !!data.vendor?.consents?.[vendorID];
   }
@@ -103,12 +178,9 @@ function tcfPurpose(data: tcf.cmpapi.TCData, purpose: number, vendorID?: number)
 }
 
 function gppCanPurpose(data: gpp.cmpapi.PingReturn, purpose: number, vendorID?: number): boolean {
-  if (!data.applicableSections.includes(gpp.tcfcav1.SectionID)) {
-    return true;
-  }
   const includeImplied = purpose > 1;
 
-  const section = data.parsedSections[gpp.tcfcav1.APIPrefix] || [];
+  const section = data.parsedSections?.[gpp.tcfcav1.APIPrefix] || [];
   if (typeof vendorID === "number") {
     const coreSegment = section.find((s) => "Version" in s);
     if (!coreSegment) {
@@ -135,13 +207,9 @@ function gppCanPurpose(data: gpp.cmpapi.PingReturn, purpose: number, vendorID?: 
 }
 
 function gppEuPurpose(data: gpp.cmpapi.PingReturn, purpose: number, vendorID?: number): boolean {
-  if (!data.applicableSections.includes(gpp.tcfeuv2.SectionID)) {
-    return true;
-  }
-
   const includeLegitimateInterest = purpose > 1;
 
-  const section = data.parsedSections[gpp.tcfeuv2.APIPrefix] || [];
+  const section = data.parsedSections?.[gpp.tcfeuv2.APIPrefix] || [];
   if (typeof vendorID === "number") {
     const coreSegment = section.find((s) => "Version" in s);
     if (!coreSegment) {
@@ -210,5 +278,5 @@ function hasTCF(): boolean {
   return typeof window.__tcfapi === "function";
 }
 
-export { getConsent, inferRegulation };
+export { getConsent, inferRegulation, applicableReg };
 export type { Consent, CMPApiConfig };

--- a/lib/core/regs/gpp/cmpapi.ts
+++ b/lib/core/regs/gpp/cmpapi.ts
@@ -37,7 +37,7 @@ type PingReturn = {
   sectionList: number[];
   applicableSections: number[];
   gppString: string;
-  parsedSections: ParsedSections;
+  parsedSections?: ParsedSections;
 };
 
 type AddEventListener = {

--- a/lib/core/regs/gpp/sections.ts
+++ b/lib/core/regs/gpp/sections.ts
@@ -1,18 +1,62 @@
-export * as tcfcav1 from "./tcfcav1";
-export * as tcfeuv2 from "./tcfeuv2";
-export * as usnat from "./usnat";
-export * as usca from "./usca";
-export * as usco from "./usco";
-export * as usct from "./usct";
-export * as usde from "./usde";
-export * as usfl from "./usfl";
-export * as usia from "./usia";
-export * as usmt from "./usmt";
-export * as usne from "./usne";
-export * as usnh from "./usnh";
-export * as usnj from "./usnj";
-export * as usor from "./usor";
-export * as ustn from "./ustn";
-export * as ustx from "./ustx";
-export * as usut from "./usut";
-export * as usva from "./usva";
+import * as tcfcav1 from "./tcfcav1";
+import * as tcfeuv2 from "./tcfeuv2";
+import * as usnat from "./usnat";
+import * as usca from "./usca";
+import * as usco from "./usco";
+import * as usct from "./usct";
+import * as usde from "./usde";
+import * as usfl from "./usfl";
+import * as usia from "./usia";
+import * as usmt from "./usmt";
+import * as usne from "./usne";
+import * as usnh from "./usnh";
+import * as usnj from "./usnj";
+import * as usor from "./usor";
+import * as ustn from "./ustn";
+import * as ustx from "./ustx";
+import * as usut from "./usut";
+import * as usva from "./usva";
+
+export const euSections = [tcfeuv2];
+
+export const caSections = [tcfcav1];
+
+export const usSections = [
+  usnat,
+  usca,
+  usco,
+  usct,
+  usde,
+  usfl,
+  usia,
+  usmt,
+  usne,
+  usnh,
+  usnj,
+  usor,
+  ustn,
+  ustx,
+  usut,
+  usva,
+];
+
+export {
+  tcfcav1,
+  tcfeuv2,
+  usnat,
+  usca,
+  usco,
+  usct,
+  usde,
+  usfl,
+  usia,
+  usmt,
+  usne,
+  usnh,
+  usnj,
+  usor,
+  ustn,
+  ustx,
+  usut,
+  usva,
+};

--- a/lib/core/regs/gpp/sections.ts
+++ b/lib/core/regs/gpp/sections.ts
@@ -17,27 +17,27 @@ import * as ustx from "./ustx";
 import * as usut from "./usut";
 import * as usva from "./usva";
 
-export const euSections = [tcfeuv2];
+export const euSectionIDs = [tcfeuv2.SectionID];
 
-export const caSections = [tcfcav1];
+export const caSectionIDs = [tcfcav1.SectionID];
 
-export const usSections = [
-  usnat,
-  usca,
-  usco,
-  usct,
-  usde,
-  usfl,
-  usia,
-  usmt,
-  usne,
-  usnh,
-  usnj,
-  usor,
-  ustn,
-  ustx,
-  usut,
-  usva,
+export const usSectionIDs = [
+  usnat.SectionID,
+  usca.SectionID,
+  usco.SectionID,
+  usct.SectionID,
+  usde.SectionID,
+  usfl.SectionID,
+  usia.SectionID,
+  usmt.SectionID,
+  usne.SectionID,
+  usnh.SectionID,
+  usnj.SectionID,
+  usor.SectionID,
+  ustn.SectionID,
+  ustx.SectionID,
+  usut.SectionID,
+  usva.SectionID,
 ];
 
 export {

--- a/lib/core/regs/regulations.ts
+++ b/lib/core/regs/regulations.ts
@@ -1,61 +1,130 @@
 type Regulation = "gdpr" | "us" | "can";
 
 const zones: { [k: string]: Regulation } = {
-  // EU
-  "Europe/Amsterdam": "gdpr",
-  "Europe/Athens": "gdpr",
-  "Europe/Berlin": "gdpr",
-  "Europe/Brussels": "gdpr",
-  "Europe/Bucharest": "gdpr",
-  "Europe/Budapest": "gdpr",
-  "Europe/Copenhagen": "gdpr",
-  "Europe/Dublin": "gdpr",
-  "Europe/Helsinki": "gdpr",
-  "Europe/Lisbon": "gdpr",
-  "Europe/London": "gdpr",
-  "Europe/Madrid": "gdpr",
-  "Europe/Oslo": "gdpr",
-  "Europe/Paris": "gdpr",
-  "Europe/Prague": "gdpr",
-  "Europe/Rome": "gdpr",
-  "Europe/Sofia": "gdpr",
-  "Europe/Stockholm": "gdpr",
+  // GDPR: EEA
+  // Austria
   "Europe/Vienna": "gdpr",
+  // Belgium
+  "Europe/Brussels": "gdpr",
+  // Bulgaria
+  "Europe/Sofia": "gdpr",
+  // Croatia
+  "Europe/Zagreb": "gdpr",
+  // Cyprus
+  "Asia/Nicosia": "gdpr",
+  "Europe/Nicosia": "gdpr",
+  // Czech Republic
+  "Europe/Prague": "gdpr",
+  // Denmark
+  "Europe/Copenhagen": "gdpr",
+  // Estonia
+  "Europe/Tallinn": "gdpr",
+  // Finland
+  "Europe/Helsinki": "gdpr",
+  // France
+  "Europe/Paris": "gdpr",
+  // Germany
+  "Europe/Berlin": "gdpr",
+  // Greece
+  "Europe/Athens": "gdpr",
+  // Hungary
+  "Europe/Budapest": "gdpr",
+  // Iceland
+  "Atlantic/Reykjavik": "gdpr",
+  // Ireland
+  "Europe/Dublin": "gdpr",
+  // Italy
+  "Europe/Rome": "gdpr",
+  // Latvia
+  "Europe/Riga": "gdpr",
+  // Liechtenstein
+  "Europe/Vaduz": "gdpr",
+  // Lithuania
+  "Europe/Vilnius": "gdpr",
+  // Luxembourg
+  "Europe/Luxembourg": "gdpr",
+  // Malta
+  "Europe/Malta": "gdpr",
+  // Norway
+  "Europe/Oslo": "gdpr",
+  // Poland
   "Europe/Warsaw": "gdpr",
-  "Europe/Zurich": "gdpr",
+  // Portugal
+  "Europe/Lisbon": "gdpr",
+  // Romania
+  "Europe/Bucharest": "gdpr",
+  // Slovakia
+  "Europe/Bratislava": "gdpr",
+  // Slovenia
+  "Europe/Ljubljana": "gdpr",
+  // Spain
+  "Europe/Madrid": "gdpr",
+  // Sweden
+  "Europe/Stockholm": "gdpr",
+  // The Netherlands
+  "Europe/Amsterdam": "gdpr",
 
-  // CA (QC only)
+  // GDPR: Outside EEA
+  // Azores
+  "Atlantic/Azores": "gdpr",
+  // Canary Islands
+  "Atlantic/Canary": "gdpr",
+  // French Guiana
+  "America/Cayenne": "gdpr",
+  // Guadeloupe
+  "America/Guadeloupe": "gdpr",
+  // Madeira
+  "Atlantic/Madeira": "gdpr",
+  // Martinique
+  "America/Martinique": "gdpr",
+  // Mayotte
+  "Indian/Mayotte": "gdpr",
+  // Reunion
+  "Indian/Reunion": "gdpr",
+  // Saint Martin
+  "America/Marigot": "gdpr",
+  // Switzerland
+  "Europe/Zurich": "gdpr",
+  // United Kingdom
+  "Europe/London": "gdpr",
+
+  // CAN: QC
   "America/Toronto": "can",
 
   // US
-  "America/New_York": "us",
+  "America/Adak": "us",
+  "America/Anchorage": "us",
+  "America/Atka": "us",
+  "America/Boise": "us",
+  "America/Chicago": "us",
+  "America/Denver": "us",
   "America/Detroit": "us",
-  "America/Kentucky/Louisville": "us",
-  "America/Kentucky/Monticello": "us",
   "America/Indiana/Indianapolis": "us",
-  "America/Indiana/Vincennes": "us",
-  "America/Indiana/Winamac": "us",
+  "America/Indiana/Knox": "us",
   "America/Indiana/Marengo": "us",
   "America/Indiana/Petersburg": "us",
-  "America/Indiana/Vevay": "us",
-  "America/Chicago": "us",
   "America/Indiana/Tell_City": "us",
-  "America/Indiana/Knox": "us",
+  "America/Indiana/Vevay": "us",
+  "America/Indiana/Vincennes": "us",
+  "America/Indiana/Winamac": "us",
+  "America/Indianapolis": "us",
+  "America/Juneau": "us",
+  "America/Kentucky/Louisville": "us",
+  "America/Kentucky/Monticello": "us",
+  "America/Knox_IN": "us",
+  "America/Los_Angeles": "us",
+  "America/Louisville": "us",
   "America/Menominee": "us",
+  "America/Metlakatla": "us",
+  "America/New_York": "us",
+  "America/Nome": "us",
+  "America/North_Dakota/Beulah": "us",
   "America/North_Dakota/Center": "us",
   "America/North_Dakota/New_Salem": "us",
-  "America/North_Dakota/Beulah": "us",
-  "America/Denver": "us",
-  "America/Boise": "us",
   "America/Phoenix": "us",
-  "America/Los_Angeles": "us",
-  "America/Anchorage": "us",
-  "America/Juneau": "us",
+  "America/Shiprock": "us",
   "America/Sitka": "us",
-  "America/Metlakatla": "us",
   "America/Yakutat": "us",
-  "America/Nome": "us",
-  "America/Adak": "us",
   "Pacific/Honolulu": "us",
 };
 


### PR DESCRIPTION
- Stop passing detected regulation to DCN, let it infer it as it may use more accurate signals (geoip)

- Rename "tcf" query param to "gdpr_consent" (aligns with TCFv2 examples of full tc passing https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#full-tc-string-passing)

- Pass along gdprApplies from CMP as "gdpr" number

- Use tcf's `gdprApplies` and gpp's `applicableSections` when defined by CMP to infer applicable regulation / handle consent.
Eg: `gdprApplies: true` forces `reg: gdpr` regardless what was initially detected.

- Add missing timezones for GDPR detection
