### PR TITLE
Multi-Node host support. Site Origin removal from cache keygen.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ demos/react/dist
 demos/npm/dist
 nginx/tls
 !nginx/tls/.gitkeep
+nginx/templates/*.conf
 
 browser/dist/
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ deps:
 export SDK_URI ?= https://localhost:8181/sdk.js
 export DCN_HOST ?= sandbox.optable.co
 export DCN_SITE ?= web-sdk-demo
+export DCN_NODE ?= 
+export DCN_LEGACYHOSTCACHE ?=
 export DCN_INIT ?= true
 export DCN_ID ?= optable
 export ADS_HOST ?= ads.optable.co
@@ -36,6 +38,8 @@ DEMO_VARS:='\
 	SDK_URI=$${SDK_URI} \
 	DCN_HOST=$${DCN_HOST} \
 	DCN_SITE=$${DCN_SITE} \
+	DCN_NODE=$${DCN_NODE} \
+	DCN_LEGACYHOSTCACHE=$${DCN_LEGACYHOSTCACHE} \
 	DCN_ID=$${DCN_ID} \
 	DCN_INIT=$${DCN_INIT} \
 	ADS_SITE=$${ADS_SITE} \

--- a/README.md
+++ b/README.md
@@ -92,9 +92,45 @@ const sdk = new OptableSDK({ host: "dcn.customer.com", site: "my-site", cookies:
 
 Note that the default is `cookies: true` and will be inferred if you do not specify the `cookies` parameter at all.
 
-## Using (npm module)
+# Using (npm module)
 
-To configure an instance of `OptableSDK` integrating with an [Optable](https://optable.co/) DCN running at hostname `dcn.customer.com`, from a configured web site origin identified by slug `my-site`, you simply create an instance of the `OptableSDK` class exported by the `@optable/web-sdk` module:
+## Initialization Configuration (`InitConfig`)
+
+When creating an instance of `OptableSDK`, you can pass an `InitConfig` object to customize its behavior. Below are the available configuration keys and their descriptions:
+
+### Required Keys
+
+- **`site` (string)**
+  The identifier (slug) of Javascript SDK source. This must match a configured site in the [Optable](https://optable.co/) DCN. Must have properly configure `Allowed HTTP Origins`.
+
+- **`host` (string)**
+  The hostname of the Optable DCN to which the SDK will connect. All API requests will be directed here.
+
+### Optional Keys
+
+- **`node` (string)**
+  If supported by the DCN host, specify the API node for SDK requests. Used in multi-node environments.
+
+- **`cookies` (boolean, default: `true`)**
+  If `true`, enables the use of browser cookies for storage.
+
+- **`legacyHostCache` (string)**
+  Used when migrating from one DCN host to another. If specified, it retains the previous cache state when switching hosts.
+
+- **`initPassport` (boolean, default: `true`)**
+  If `true`, initializes the user passport (identity mechanism) upon SDK load.
+
+- **`consent` (`InitConsent`)**
+  Defines the consent settings for data collection and processing.
+
+- **`readOnly` (boolean, default: `false`)**
+  When set to `true`, puts the SDK in a read-only mode, preventing any data modifications while still allowing API queries.
+
+These configurations allow fine-tuned control over how the `OptableSDK` interacts with the Optable DCN, ensuring compatibility with different environments and privacy settings.
+
+## Usage Example
+
+To configure an instance of `OptableSDK` integrating with an Optable DCN running at hostname `dcn.customer.com`, from a configured web site origin identified by slug `my-site`, you simply create an instance of the `OptableSDK` class exported by the `@optable/web-sdk` module:
 
 ```js
 import OptableSDK from "@optable/web-sdk";
@@ -102,9 +138,12 @@ import OptableSDK from "@optable/web-sdk";
 const sdk = new OptableSDK({ host: "dcn.customer.com", site: "my-site" });
 ```
 
-You can then call various SDK APIs on the instance as shown in the examples below. It's also possible to configure multiple instances of `OptableSDK` in order to connect to other (e.g., partner) DCNs and/or reference other configured web site slug IDs.
+You can then call various SDK APIs on the instance as shown in the examples below. It is also possible to configure multiple instances of `OptableSDK` in order to connect to different DCNs or reference multiple site slugs.
 
-Note that all SDK communication with Optable DCNs is done over TLS.
+### Security & Privacy
+
+- All SDK communication with Optable DCNs is done over TLS to ensure data security.
+- The `consent` option allows compliance with privacy regulations by defining explicit data collection settings.
 
 ### Identify API
 

--- a/demos/react/webpack.config.js
+++ b/demos/react/webpack.config.js
@@ -28,7 +28,9 @@ module.exports = {
       DCN_CONFIG: JSON.stringify({
         host: process.env.DCN_HOST,
         initPassport: process.env.DCN_INIT === "true",
-        site: "${DCN_SITE}",
+        site: process.env.DCN_SITE,
+        node: process.env.DCN_NODE,
+        legacyHostCache: process.env.DCN_LEGACY_HOST_CACHE,
       }),
     }),
     new HtmlWebpackPlugin({

--- a/demos/vanilla/identify.html.tpl
+++ b/demos/vanilla/identify.html.tpl
@@ -20,6 +20,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/identify.html.tpl
+++ b/demos/vanilla/nocookies/identify.html.tpl
@@ -21,6 +21,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/profile.html.tpl
+++ b/demos/vanilla/nocookies/profile.html.tpl
@@ -21,6 +21,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360-cached.html.tpl
@@ -21,6 +21,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/targeting/gam360.html.tpl
+++ b/demos/vanilla/nocookies/targeting/gam360.html.tpl
@@ -21,6 +21,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/targeting/prebid.html.tpl
+++ b/demos/vanilla/nocookies/targeting/prebid.html.tpl
@@ -27,6 +27,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/nocookies/witness.html.tpl
+++ b/demos/vanilla/nocookies/witness.html.tpl
@@ -21,6 +21,8 @@
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
           cookies: false,
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/profile.html.tpl
+++ b/demos/vanilla/profile.html.tpl
@@ -20,6 +20,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/gam360-cached.html.tpl
+++ b/demos/vanilla/targeting/gam360-cached.html.tpl
@@ -20,6 +20,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/gam360.html.tpl
+++ b/demos/vanilla/targeting/gam360.html.tpl
@@ -20,6 +20,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/targeting/prebid.html.tpl
+++ b/demos/vanilla/targeting/prebid.html.tpl
@@ -26,6 +26,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/uid2_token/login.html.tpl
+++ b/demos/vanilla/uid2_token/login.html.tpl
@@ -22,6 +22,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/demos/vanilla/witness.html.tpl
+++ b/demos/vanilla/witness.html.tpl
@@ -20,6 +20,8 @@
           host: "${DCN_HOST}",
           initPassport: JSON.parse("${DCN_INIT}"),
           site: "${DCN_SITE}",
+          node: "${DCN_NODE}",
+          legacyHostCache: "${DCN_LEGACY_HOST_CACHE}",
         });
 
         optable.instance.tryIdentifyFromParams();

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -23,6 +23,8 @@ describe("getConfig", () => {
         initPassport: false,
         consent: { static: defaultConsent },
         readOnly: true,
+        node: "my-node",
+        legacyHostCache: "legacy-cache",
       })
     ).toEqual({
       host: "host",
@@ -31,6 +33,8 @@ describe("getConfig", () => {
       initPassport: false,
       consent: defaultConsent,
       readOnly: true,
+      node: "my-node",
+      legacyHostCache: "legacy-cache",
     });
   });
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,16 +9,28 @@ type InitConsent = {
 };
 
 type InitConfig = {
-  host: string;
+  // Source slug for SDK calls
   site: string;
+  // API host
+  host: string;
+  // Node for API calls (only set if required by the host)
+  node?: string;
+  // Enable cookie storage
   cookies?: boolean;
+  // Previous Host, used only when switching hosts to retain previous cache state
+  legacyHostCache?: string;
+  // Initialize passport on SDK load
   initPassport?: boolean;
+  // Consent settings
   consent?: InitConsent;
+  // Enable read-only mode
   readOnly?: boolean;
 };
 
-type ResolvedConfig = Required<Omit<InitConfig, "consent">> & {
+type ResolvedConfig = Required<Omit<InitConfig, "consent" | "node" | "legacyHostCache">> & {
   consent: Consent;
+  node?: string;
+  legacyHostCache?: string;
 };
 
 const DCN_DEFAULTS = {
@@ -42,6 +54,8 @@ function getConfig(init: InitConfig): ResolvedConfig {
     initPassport: init.initPassport ?? DCN_DEFAULTS.initPassport,
     consent: DCN_DEFAULTS.consent,
     readOnly: init.readOnly ?? DCN_DEFAULTS.readOnly,
+    node: init.node,
+    legacyHostCache: init.legacyHostCache,
   };
 
   if (init.consent?.static) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -27,9 +27,14 @@ type InitConfig = {
   readOnly?: boolean;
 };
 
-type ResolvedConfig = Required<Omit<InitConfig, "consent" | "node" | "legacyHostCache">> & {
+type ResolvedConfig = {
+  site: string;
+  host: string;
   consent: Consent;
   node?: string;
+  cookies?: boolean;
+  initPassport?: boolean;
+  readOnly?: boolean;
   legacyHostCache?: string;
 };
 

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -7,6 +7,7 @@ describe("buildRequest", () => {
       cookies: true,
       host: "host",
       site: "site",
+      node: "my-node",
       consent: { reg: "can", gpp: "gpp", gppSectionIDs: [1, 2] },
     };
 
@@ -20,6 +21,7 @@ describe("buildRequest", () => {
     expect([...url.searchParams.entries()]).toEqual([
       ["query", "string"],
       ["osdk", `web-${buildInfo.version}`],
+      ["t", dcn.node],
       ["gpp", "gpp"],
       ["gpp_sid", "1,2"],
       ["cookies", "yes"],

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -8,6 +8,10 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   const url = new URL(`${site}${path}`, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
 
+  if (config.node) {
+    url.searchParams.set("t", config.node);
+  }
+
   if (typeof config.consent.gpp !== "undefined") {
     url.searchParams.set("gpp", config.consent.gpp);
   }

--- a/lib/core/storage.test.js
+++ b/lib/core/storage.test.js
@@ -1,6 +1,6 @@
 import { DCN_DEFAULTS } from "../config";
-import LocalStorage from "./storage";
 import crypto from "crypto";
+import LocalStorage, { deprecatedGenerateCacheKey, generateCacheKey, encodeBase64 } from "./storage";
 
 function randomConfig() {
   const randomHex = crypto.randomBytes(8).toString("hex");
@@ -50,5 +50,71 @@ describe("LocalStorage", () => {
     const store = new LocalStorage(randomConfig());
     expect(store.setSite());
     expect(store.getSite()).toBeNull();
+  });
+
+  test("reads from deprecated cache if new cache is empty but only writes to new cache", () => {
+    const config = randomConfig();
+    const store = new LocalStorage(config);
+    const deprecatedKey = `OPTABLE_PASS_${deprecatedGenerateCacheKey(config)}`;
+    const newKey = `OPTABLE_PASSPORT_${generateCacheKey(config)}`;
+
+    localStorage.setItem(deprecatedKey, "deprecated-value");
+    expect(store.getPassport()).toEqual("deprecated-value");
+
+    store.setPassport("new-value");
+    expect(store.getPassport()).toEqual("new-value");
+    expect(localStorage.getItem(newKey)).toEqual("new-value");
+    expect(localStorage.getItem(deprecatedKey)).toEqual("deprecated-value");
+
+    localStorage.removeItem(deprecatedKey);
+    localStorage.removeItem(newKey);
+  });
+
+  test("prioritizes new cache over deprecated cache", () => {
+    const config = randomConfig();
+    const store = new LocalStorage(config);
+    const deprecatedKey = `OPTABLE_PASS_${deprecatedGenerateCacheKey(config)}`;
+    const newKey = `OPTABLE_PASSPORT_${generateCacheKey(config)}`;
+
+    localStorage.setItem(deprecatedKey, "deprecated-value");
+    localStorage.setItem(newKey, "new-value");
+    expect(store.getPassport()).toEqual("new-value");
+
+    localStorage.removeItem(deprecatedKey);
+    localStorage.removeItem(newKey);
+  });
+});
+
+describe("Cache Key Generation", () => {
+  const mockConfig = (overrides = {}) => ({
+    host: "example.com",
+    site: "test-site",
+    node: "node123",
+    legacyHostCache: "legacy.example.com",
+    ...overrides,
+  });
+
+  test("deprecatedGenerateCacheKey uses legacyHostCache if present", () => {
+    const config = mockConfig();
+    const expectedKey = encodeBase64(`${config.legacyHostCache}/${config.site}`);
+    expect(deprecatedGenerateCacheKey(config)).toEqual(expectedKey);
+  });
+
+  test("deprecatedGenerateCacheKey falls back to host if legacyHostCache is missing", () => {
+    const config = mockConfig({ legacyHostCache: undefined });
+    const expectedKey = encodeBase64(`${config.host}/${config.site}`);
+    expect(deprecatedGenerateCacheKey(config)).toEqual(expectedKey);
+  });
+
+  test("generateCacheKey uses host and node if node exists", () => {
+    const config = mockConfig();
+    const expectedKey = encodeBase64(`${config.host}/${config.node}`);
+    expect(generateCacheKey(config)).toEqual(expectedKey);
+  });
+
+  test("generateCacheKey falls back to host if node is missing", () => {
+    const config = mockConfig({ node: undefined });
+    const expectedKey = encodeBase64(config.host);
+    expect(generateCacheKey(config)).toEqual(expectedKey);
   });
 });


### PR DESCRIPTION
This PR is adding support for Multi-Node Hosts with backward compatibility.

**_Init Config changes:_**
- Added logic to include the node parameter as t=node in the SDK requests if a node is provided in the InitConfig.
- Added LegacyHostCache parameter to support host switching without loss of cache.

_* It’s important to note that the node field should only be specified if the host supports multiple nodes; otherwise, the SDK will not function correctly when the node is set._

**_Local Storage Changes:_**
- Remove site dependancy from cache key
- Refactored cache key generation to prioritize new keys while maintaining backward compatibility.
- Introduced generateCacheKey and deprecatedGenerateCacheKey for structured key management.
- Updated LocalStorage to read from deprecated cache if the new cache is empty but write only to the new cache.
- Added getFirstExistingItem helper to streamline key fallback logic.
- Ensured clearPassport removes both old and new cache keys.

**_Added Test Coverage:_**
- reads from deprecated cache if new cache is empty but only writes to new cache
- prioritizes new cache over deprecated cache
- deprecatedGenerateCacheKey uses legacyHostCache if present
- deprecatedGenerateCacheKey falls back to host if legacyHostCache is missing
- generateCacheKey uses host and node if node exists
- generateCacheKey falls back to host if node is missing