### PR TITLE
Explicitly omit cookies unless device access is granted

### DIFF
--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -25,4 +25,20 @@ describe("buildRequest", () => {
       ["cookies", "yes"],
     ]);
   });
+
+  it("omits credentials when device access isnt granted", () => {
+    const dcn = {
+      cookies: true,
+      host: "host",
+      site: "site",
+      consent: { deviceAccess: false },
+    };
+    let request = buildRequest("/endpoint", dcn, { method: "GET" });
+    expect(request.credentials).toBe("omit");
+
+    dcn.consent.deviceAccess = true;
+
+    request = buildRequest("/endpoint", dcn, { method: "GET" });
+    expect(request.credentials).toBe("include");
+  });
 });

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -38,7 +38,7 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   }
 
   const requestInit: RequestInit = { ...init };
-  requestInit.credentials = "include";
+  requestInit.credentials = config.consent.deviceAccess ? "include" : "omit";
 
   const request = new Request(url.toString(), requestInit);
 


### PR DESCRIPTION
This prevents any cookies from being accessed/stored on device when communicating with edge when device access isn't granted.