### PR TITLE
Add Multi node targeting resolver

### DIFF
--- a/browser/sdk.ts
+++ b/browser/sdk.ts
@@ -1,4 +1,5 @@
 import Commands from "./commands";
+import { resolveMultiNodeTargeting } from "../lib/core/resolvers/resolveMultiTargeting";
 
 import OptableSDK from "../lib/sdk";
 import "../lib/addons/gpt";
@@ -9,6 +10,7 @@ import "../lib/addons/topics-api";
 type OptableGlobal = {
   cmd: Commands | Function[];
   SDK: OptableSDK["constructor"];
+  utils: Record<string, Function>;
 };
 
 declare global {
@@ -23,3 +25,4 @@ declare global {
 window.optable = window.optable || {};
 window.optable.SDK = OptableSDK;
 window.optable.cmd = new Commands(window.optable.cmd || []);
+window.optable.utils = { resolveMultiNodeTargeting };

--- a/lib/core/resolvers/resolveMultiTargeting.test.ts
+++ b/lib/core/resolvers/resolveMultiTargeting.test.ts
@@ -1,0 +1,271 @@
+import { resolveMultiNodeTargeting, TargetingResponse } from "./resolveMultiTargeting.ts";
+import { IDMatchMethod } from "iab-adcom";
+
+const createOrtb2Response = ({ data = [], eids = [] }: { data?: any; eids?: any }) => {
+  return {
+    ortb2: {
+      user: {
+        data,
+        eids,
+      },
+    },
+  };
+};
+
+describe("resolveMultiNodeTargeting", () => {
+  test("properly aggregates all eids with sources", async () => {
+    const matcherOneMMThree = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          data: [
+            { id: "data1", name: "Provider1" },
+            { id: "data2", name: "Provider2" },
+          ],
+          eids: [
+            { inserter: "optable.co", source: "uid2.com", uids: [{ id: "uid123" }, { id: "uid456" }] },
+            { inserter: "optable.co", source: "criteo.com", uids: [{ id: "uid123" }, { id: "uid456" }] },
+          ],
+        })
+      );
+    });
+
+    const matcherTwoMMFive = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          data: [],
+          eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }],
+        })
+      );
+    });
+
+    const matcherThreeMMFive = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          eids: [{ inserter: "optable.co", source: "another-place.com", uids: [{ id: "some-id" }] }],
+        })
+      );
+    });
+
+    const configs = [
+      { targetingFn: () => matcherOneMMThree, matcher: "matcher_one", mm: IDMatchMethod.AUTHENTICATED },
+      { targetingFn: () => matcherTwoMMFive, matcher: "matcher_two", mm: IDMatchMethod.INFERENCE },
+      { targetingFn: () => matcherThreeMMFive, matcher: "matcher_three", mm: IDMatchMethod.INFERENCE },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(ortb2.user!.data).toEqual([
+      { id: "data1", name: "Provider1" },
+      { id: "data2", name: "Provider2" },
+    ]);
+    expect(ortb2.user!.eids).toEqual([
+      {
+        inserter: "optable.co",
+        matcher: "matcher_one",
+        mm: IDMatchMethod.AUTHENTICATED,
+        source: "uid2.com",
+        uids: [{ id: "uid123" }, { id: "uid456" }],
+      },
+      {
+        inserter: "optable.co",
+        matcher: "matcher_one",
+        mm: IDMatchMethod.AUTHENTICATED,
+        source: "criteo.com",
+        uids: [{ id: "uid123" }, { id: "uid456" }],
+      },
+      {
+        inserter: "optable.co",
+        matcher: "matcher_two",
+        mm: IDMatchMethod.INFERENCE,
+        source: "example.com",
+        uids: [{ id: "uid456" }],
+      },
+      {
+        inserter: "optable.co",
+        matcher: "matcher_three",
+        mm: IDMatchMethod.INFERENCE,
+        source: "another-place.com",
+        uids: [{ id: "some-id" }],
+      },
+    ]);
+
+    expect(eidSources).toEqual(new Set<string>(["matcher_one", "matcher_two", "matcher_three"]));
+  });
+
+  test("resolves empty responses gracefully for aggregate resolving", async () => {
+    const emptyTargetingOne = new Promise<TargetingResponse>((resolve) => resolve(createOrtb2Response({})));
+    const emptyTargetingTwo = new Promise<TargetingResponse>((resolve) => resolve(createOrtb2Response({})));
+
+    const configs = [
+      { targetingFn: () => emptyTargetingOne, matcher: "matcher_one", mm: IDMatchMethod.COOKIE_SYNC },
+      { targetingFn: () => emptyTargetingTwo, matcher: "matcher_two", mm: IDMatchMethod.COOKIE_SYNC },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(eidSources).toEqual(new Set<string>([]));
+    expect(ortb2).toEqual({ user: { data: [], eids: [] } });
+  });
+
+  test("resolves empty responses gracefully for priority resolving", async () => {
+    const emptyTargetingOne = new Promise<TargetingResponse>((resolve) => resolve(createOrtb2Response({})));
+    const emptyTargetingTwo = new Promise<TargetingResponse>((resolve) => resolve(createOrtb2Response({})));
+
+    const configs = [
+      { targetingFn: () => emptyTargetingOne, matcher: "matcher_one", mm: IDMatchMethod.COOKIE_SYNC, priority: 1 },
+      { targetingFn: () => emptyTargetingTwo, matcher: "matcher_two", mm: IDMatchMethod.COOKIE_SYNC, priority: 2 },
+    ];
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(eidSources).toEqual(new Set<string>([]));
+    expect(ortb2).toEqual({ user: { data: [], eids: [] } });
+  });
+
+  test("Resolves priority queue by lowest number", async () => {
+    const mockTargetingFnOne = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          data: [{ id: "data1", name: "Provider1" }],
+          eids: [{ inserter: "optable.co", source: "uid2.com", uids: [{ id: "uid123" }, { id: "uid456" }] }],
+        })
+      );
+    });
+
+    const mockTargetingFnTwo = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({ eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }] })
+      );
+    });
+
+    const configs = [
+      { targetingFn: () => mockTargetingFnOne, matcher: "matcher_one", mm: IDMatchMethod.AUTHENTICATED, priority: 1 },
+      { targetingFn: () => mockTargetingFnTwo, matcher: "matcher_two", mm: IDMatchMethod.INFERENCE, priority: 2 },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(ortb2.user!.data).toEqual([{ id: "data1", name: "Provider1" }]);
+    expect(ortb2.user!.eids).toEqual([
+      {
+        inserter: "optable.co",
+        matcher: "matcher_one",
+        mm: IDMatchMethod.AUTHENTICATED,
+        source: "uid2.com",
+        uids: [{ id: "uid123" }, { id: "uid456" }],
+      },
+    ]);
+
+    expect(eidSources).toEqual(new Set<string>(["matcher_one"]));
+  });
+
+  test("Same priority will merge together", async () => {
+    const mockTargetingFnOne = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          data: [{ id: "data1", name: "Provider1" }],
+          eids: [{ inserter: "optable.co", source: "uid2.com", uids: [{ id: "uid123" }, { id: "uid456" }] }],
+        })
+      );
+    });
+
+    const mockTargetingFnTwo = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({ eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }] })
+      );
+    });
+
+    const mockTargetingFnThree = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({ eids: [{ inserter: "optable.co", source: "another.com", uids: [{ id: "blah" }] }] })
+      );
+    });
+
+    const configs = [
+      { targetingFn: () => mockTargetingFnOne, matcher: "matcher_one", mm: IDMatchMethod.AUTHENTICATED, priority: 1 },
+      { targetingFn: () => mockTargetingFnTwo, matcher: "matcher_two", mm: IDMatchMethod.INFERENCE, priority: 1 },
+      { targetingFn: () => mockTargetingFnThree, matcher: "matcher_three", mm: IDMatchMethod.INFERENCE, priority: 2 },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(ortb2.user!.data).toEqual([{ id: "data1", name: "Provider1" }]);
+    expect(ortb2.user!.eids).toEqual([
+      {
+        inserter: "optable.co",
+        matcher: "matcher_one",
+        mm: IDMatchMethod.AUTHENTICATED,
+        source: "uid2.com",
+        uids: [{ id: "uid123" }, { id: "uid456" }],
+      },
+      {
+        inserter: "optable.co",
+        matcher: "matcher_two",
+        mm: IDMatchMethod.INFERENCE,
+        source: "example.com",
+        uids: [{ id: "uid456" }],
+      },
+    ]);
+
+    expect(eidSources).toEqual(new Set<string>(["matcher_one", "matcher_two"]));
+  });
+
+  test("Grabs lowest priority that HAS eids", async () => {
+    const mockTargetingFnOne = new Promise<TargetingResponse>((resolve) => {
+      resolve(createOrtb2Response({}));
+    });
+
+    const mockTargetingFnTwo = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({ eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }] })
+      );
+    });
+
+    const configs = [
+      { targetingFn: () => mockTargetingFnOne, matcher: "matcher_one", mm: IDMatchMethod.AUTHENTICATED, priority: 1 },
+      { targetingFn: () => mockTargetingFnTwo, matcher: "matcher_two", mm: IDMatchMethod.INFERENCE, priority: 2 },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(ortb2.user!.data).toEqual([]);
+    expect(ortb2.user!.eids).toEqual([
+      {
+        inserter: "optable.co",
+        matcher: "matcher_two",
+        mm: IDMatchMethod.INFERENCE,
+        source: "example.com",
+        uids: [{ id: "uid456" }],
+      },
+    ]);
+
+    expect(eidSources).toEqual(new Set<string>(["matcher_two"]));
+  });
+
+  test("ignores priorities lower then 1", async () => {
+    const mockTargetingFnOne = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({
+          data: [],
+          eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }],
+        })
+      );
+    });
+
+    const mockTargetingFnTwo = new Promise<TargetingResponse>((resolve) => {
+      resolve(
+        createOrtb2Response({ eids: [{ inserter: "optable.co", source: "example.com", uids: [{ id: "uid456" }] }] })
+      );
+    });
+
+    const configs = [
+      { targetingFn: () => mockTargetingFnOne, matcher: "matcher_one", mm: IDMatchMethod.AUTHENTICATED, priority: 0 },
+      { targetingFn: () => mockTargetingFnTwo, matcher: "matcher_two", mm: IDMatchMethod.INFERENCE, priority: -1 },
+    ];
+
+    const { ortb2, eidSources } = await resolveMultiNodeTargeting(configs);
+
+    expect(ortb2.user!.data).toEqual([]);
+    expect(ortb2.user!.eids).toEqual([]);
+    expect(eidSources).toEqual(new Set<string>([]));
+  });
+});

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -1,3 +1,4 @@
+import type { BidRequest } from "iab-openrtb/v26";
 import type { ResolvedConfig } from "../config";
 import { fetch } from "../core/network";
 import { LocalStorage } from "../core/storage";
@@ -22,6 +23,7 @@ type UserIdentifiers = {
 type TargetingResponse = {
   audience?: AudienceIdentifiers[];
   user?: UserIdentifiers[];
+  ortb2: Partial<BidRequest>;
 };
 
 async function Targeting(config: ResolvedConfig, id: string): Promise<TargetingResponse> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "iab-openrtb": "^1.0.1",
         "js-sha256": "^0.11.0",
         "regenerator-runtime": "^0.13.7"
       },
@@ -5108,6 +5109,27 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iab-adcom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
+      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/iab-openrtb": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
+      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "license": "MIT",
+      "dependencies": {
+        "iab-adcom": "1.0.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -14503,6 +14525,19 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "iab-adcom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
+      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA=="
+    },
+    "iab-openrtb": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
+      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "requires": {
+        "iab-adcom": "1.0.6"
+      }
     },
     "iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "iab-openrtb": "^1.0.1",
     "js-sha256": "^0.11.0",
     "regenerator-runtime": "^0.13.7"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["dom", "esnext"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
### **_PR Description:_**
This PR introduces resolveMultiNodeTargeting, a function that resolves multiple targeting nodes by either aggregating all resolved data or selecting the highest-priority node.

### **_Behavior:_**
- If any targeting node has a priority attribute (≥1), only the highest-priority response is used.
- If multiple nodes share the highest priority, their eids are merged.
- If no priority is set, all resolved responses are aggregated.
- Extracted eids are assigned the calling node’s matcher and mm values, with optable.co as the inserter.
- The function returns the final Ortb2Response and a list of resolved eid sources.

### **Testing**  

**_resolveMultiNodeTargeting_**
    ✓ properly aggregates all eids with sources (1 ms)
    ✓ resolves empty responses gracefully for aggregate resolving
    ✓ resolves empty responses gracefully for priority resolving (1 ms)
    ✓ Resolves priority queue by lowest number
    ✓ Same priority will merge together (1 ms)
    ✓ Grabs lowest priority that HAS eids
    ✓ ignores priorities lower then 1 (2 ms)
    ✓ Overrides match method on aggregate resolve (1 ms)
    ✓ Overrides match method on priority resolve
