### PR TITLE
experiment: Introduce tokenize v2

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -11,6 +11,7 @@ describe("getConfig", () => {
       initPassport: true,
       consent: defaultConsent,
       readOnly: false,
+      experiments: [],
     });
   });
 
@@ -25,6 +26,7 @@ describe("getConfig", () => {
         readOnly: true,
         node: "my-node",
         legacyHostCache: "legacy-cache",
+        experiments: ["tokenize-v2"],
       })
     ).toEqual({
       host: "host",
@@ -35,6 +37,7 @@ describe("getConfig", () => {
       readOnly: true,
       node: "my-node",
       legacyHostCache: "legacy-cache",
+      experiments: ["tokenize-v2"],
     });
   });
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,8 @@
 import { getConsent, inferRegulation } from "./core/regs/consent";
 import type { CMPApiConfig, Consent } from "./core/regs/consent";
 
+type Experiment = "tokenize-v2";
+
 type InitConsent = {
   // A "cmpapi" configuration indicating that consent should be gathered from CMP apis.
   cmpapi?: CMPApiConfig;
@@ -25,6 +27,8 @@ type InitConfig = {
   consent?: InitConsent;
   // Enable read-only mode
   readOnly?: boolean;
+  // Active experiments to test new features
+  experiments?: Experiment[];
 };
 
 type ResolvedConfig = {
@@ -32,16 +36,18 @@ type ResolvedConfig = {
   host: string;
   consent: Consent;
   node?: string;
-  cookies?: boolean;
-  initPassport?: boolean;
-  readOnly?: boolean;
+  cookies: boolean;
+  initPassport: boolean;
+  readOnly: boolean;
   legacyHostCache?: string;
+  experiments: Experiment[];
 };
 
 const DCN_DEFAULTS = {
   cookies: true,
   initPassport: true,
   readOnly: false,
+  experiments: [],
   consent: {
     reg: null,
     deviceAccess: true,
@@ -61,6 +67,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     readOnly: init.readOnly ?? DCN_DEFAULTS.readOnly,
     node: init.node,
     legacyHostCache: init.legacyHostCache,
+    experiments: init.experiments ?? DCN_DEFAULTS.experiments,
   };
 
   if (init.consent?.static) {

--- a/lib/edge/tokenize.ts
+++ b/lib/edge/tokenize.ts
@@ -11,10 +11,15 @@ type TokenizeRequest = {
 };
 
 function Tokenize(config: ResolvedConfig, id: string): Promise<TokenizeResponse> {
+  let endpoint = "/v1/tokenize";
+  if (config.experiments.includes("tokenize-v2")) {
+    endpoint = "/v2/tokenize";
+  }
+
   let request: TokenizeRequest = {
     id: id,
   };
-  return fetch("/v1/tokenize", config, {
+  return fetch(endpoint, config, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -223,6 +223,7 @@ describe("behavior testing of", () => {
       cookies: false,
       initPassport: false,
       readOnly: false,
+      experiments: [],
     });
     await sdk["init"];
     expect(localStorage.setItem).toBeCalledTimes(0);
@@ -261,6 +262,7 @@ describe("behavior testing of", () => {
       cookies: true,
       initPassport: true,
       readOnly: false,
+      experiments: [],
     });
     await sdk["init"];
     expect(window.localStorage.setItem).toHaveBeenLastCalledWith(
@@ -464,6 +466,20 @@ describe("behavior testing of", () => {
         method: "POST",
         _bodyText: '{"id":"someId"}',
         url: expect.stringContaining("v1/tokenize"),
+      })
+    );
+  });
+
+  test("tokenize supports v2 experiment", async () => {
+    const fetchSpy = jest.spyOn(window, "fetch");
+    const sdk = new OptableSDK({ ...defaultConfig, experiments: ["tokenize-v2"] });
+
+    await sdk.tokenize("someId");
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        _bodyText: '{"id":"someId"}',
+        url: expect.stringContaining("v2/tokenize"),
       })
     );
   });

--- a/lib/test/handlers.ts
+++ b/lib/test/handlers.ts
@@ -67,6 +67,16 @@ const handlers = [
     return HttpResponse.json({ ...data, ...passport }, ok200);
   }),
 
+  http.post(`${TEST_BASE_URL}/v2/tokenize`, async ({}) => {
+    const data: TokenizeResponse = {
+      User: {
+        data: [],
+        ext: undefined,
+      },
+    };
+    return HttpResponse.json({ ...data, ...passport }, ok200);
+  }),
+
   http.get(`${TEST_BASE_URL}/v2/targeting`, async ({}) => {
     const data: TargetingResponse = {
       audience: [],


### PR DESCRIPTION
This introduces a new config to allow users to optin experiments.

The experiment introduced by this PR allows to optin to tokenize v2 API, which introduces subtle changes (potentially breaking) on the EID response grouping logic:

- instead of emit a EID per individual UID, all UIDs sharing the same source/matcher/mm will be grouped together:
```
eids: [{source: "s1", matcher: "m1", uids: [{id: "abc"}]}, {source: "s1", matcher: "m1", uids: [{id: "def"}]}]
```
will become
```
eids: [{source: "s1", matcher: "m1", uids: [{id: "abc"}, {id: "def"}]}]
```

- EIDs that have no UIDs will not be emitted in the response. This use to be already the case for all EID source but "optable.co" and "pair-protocol.com". In tokenize-v2 both of those are aligned with the others.

Experiments may graduate to features or be removed in the future. In both cases, this would lead to a major SDK bump.