### PR TITLE
Improve Cache key mechanism.

### DIFF
--- a/lib/core/storage-keys.test.js
+++ b/lib/core/storage-keys.test.js
@@ -43,8 +43,8 @@ describe("Storage Key Generation", () => {
       read: [
         "OPTABLE_PASSPORT_" + encodeBase64("example.com/node1"),
         "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
-        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
         "OPTABLE_PASSPORT_" + encodeBase64("legacy.example.com"),
+        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
       ],
     });
   });
@@ -56,8 +56,8 @@ describe("Storage Key Generation", () => {
       write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com")],
       read: [
         "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
-        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
         "OPTABLE_PASSPORT_" + encodeBase64("legacy.example.com"),
+        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
       ],
     });
   });

--- a/lib/core/storage-keys.test.js
+++ b/lib/core/storage-keys.test.js
@@ -1,0 +1,77 @@
+import { generateSiteKeys, generatePassportKeys, generateTargetingKeys, encodeBase64 } from "./storage-keys";
+
+describe("Storage Key Generation", () => {
+  const mockConfig = {
+    host: "example.com",
+    node: "node1",
+    site: "site1",
+    legacyHostCache: "legacy.example.com",
+  };
+
+  test("generateSiteKeys should return correct storage keys", () => {
+    const keysWithNodeConfig = generateSiteKeys(mockConfig);
+    expect(keysWithNodeConfig).toEqual({
+      write: ["OPTABLE_SITE_" + encodeBase64("example.com/node1")],
+      read: ["OPTABLE_SITE_" + encodeBase64("example.com/node1")],
+    });
+
+    const keysWithoutNodeConfig = generateSiteKeys({ ...mockConfig, node: undefined });
+    expect(keysWithoutNodeConfig).toEqual({
+      write: ["OPTABLE_SITE_" + encodeBase64("example.com")],
+      read: ["OPTABLE_SITE_" + encodeBase64("example.com")],
+    });
+  });
+
+  test("generateTargetingKeys should return correct storage keys", () => {
+    const keysWithNodeConfig = generateTargetingKeys(mockConfig);
+    expect(keysWithNodeConfig).toEqual({
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
+      read: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
+    });
+
+    const keysWithoutNodeConfig = generateTargetingKeys({ ...mockConfig, node: undefined });
+    expect(keysWithoutNodeConfig).toEqual({
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com")],
+      read: ["OPTABLE_TARGETING_" + encodeBase64("example.com")],
+    });
+  });
+
+  test("passport keys WITH NODE should write/read that first", () => {
+    const keys = generatePassportKeys(mockConfig);
+    expect(keys).toEqual({
+      write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com/node1")],
+      read: [
+        "OPTABLE_PASSPORT_" + encodeBase64("example.com/node1"),
+        "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
+        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
+        "OPTABLE_PASSPORT_" + encodeBase64("legacy.example.com"),
+      ],
+    });
+  });
+
+  test("passport keys NO NODE should write/read that first", () => {
+    const configWithoutNode = { ...mockConfig, node: undefined };
+    const keys = generatePassportKeys(configWithoutNode);
+    expect(keys).toEqual({
+      write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com")],
+      read: [
+        "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
+        "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
+        "OPTABLE_PASSPORT_" + encodeBase64("legacy.example.com"),
+      ],
+    });
+  });
+
+  test("passport keys NO LegacyHostCache doesn't use as read key", () => {
+    const configWithoutLegacyHost = { ...mockConfig, legacyHostCache: undefined };
+    const keys = generatePassportKeys(configWithoutLegacyHost);
+    expect(keys).toEqual({
+      write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com/node1")],
+      read: [
+        "OPTABLE_PASSPORT_" + encodeBase64("example.com/node1"),
+        "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
+        "OPTABLE_PASS_" + encodeBase64("example.com/site1"),
+      ],
+    });
+  });
+});

--- a/lib/core/storage-keys.test.js
+++ b/lib/core/storage-keys.test.js
@@ -42,7 +42,6 @@ describe("Storage Key Generation", () => {
       write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com/node1")],
       read: [
         "OPTABLE_PASSPORT_" + encodeBase64("example.com/node1"),
-        "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
         "OPTABLE_PASSPORT_" + encodeBase64("legacy.example.com"),
         "OPTABLE_PASS_" + encodeBase64("legacy.example.com/site1"),
       ],
@@ -69,7 +68,6 @@ describe("Storage Key Generation", () => {
       write: ["OPTABLE_PASSPORT_" + encodeBase64("example.com/node1")],
       read: [
         "OPTABLE_PASSPORT_" + encodeBase64("example.com/node1"),
-        "OPTABLE_PASSPORT_" + encodeBase64("example.com"),
         "OPTABLE_PASS_" + encodeBase64("example.com/site1"),
       ],
     });

--- a/lib/core/storage-keys.ts
+++ b/lib/core/storage-keys.ts
@@ -54,11 +54,6 @@ function generatePassportKeys(config: ResolvedConfig): StorageKeys {
   write.push(writeKey);
   read.push(writeKey);
 
-  // Allows switching from host to host/node without losing cache
-  if (config.node) {
-    read.push(`OPTABLE_PASSPORT_${encodeBase64(`${config.host}`)}`);
-  }
-
   // We keep `OPTABLE_PASS` keys for backward compatibility
   // Once all clients are updated, we can remove them on next tag
   if (config.legacyHostCache) {

--- a/lib/core/storage-keys.ts
+++ b/lib/core/storage-keys.ts
@@ -1,0 +1,75 @@
+import type { ResolvedConfig } from "../config";
+
+const pairStorageKey = "_optable_pairId";
+
+type StorageKeys = { write: string[]; read: string[] };
+
+export function encodeBase64(str: string): string {
+  const codeUnits = new Uint16Array(str.length);
+  for (let i = 0; i < codeUnits.length; i++) {
+    codeUnits[i] = str.charCodeAt(i);
+  }
+  return btoa(String.fromCharCode(...new Uint8Array(codeUnits.buffer)));
+}
+
+function getWriteKeyBase64FromConfig(config: ResolvedConfig): string {
+  if (config.node) {
+    return encodeBase64(`${config.host}/${config.node}`);
+  }
+
+  return encodeBase64(`${config.host}`);
+}
+
+// Generate the keys for the site storage
+// The keys are generated based on the host and node configs
+function generateSiteKeys(config: ResolvedConfig): StorageKeys {
+  const key = `OPTABLE_SITE_${getWriteKeyBase64FromConfig(config)}`;
+
+  return { write: [key], read: [key] };
+}
+
+// Generate the keys for the targeting storage
+// The keys are generated based on the host and node configs
+function generateTargetingKeys(config: ResolvedConfig): StorageKeys {
+  const key = `OPTABLE_TARGETING_${getWriteKeyBase64FromConfig(config)}`;
+
+  return { write: [key], read: [key] };
+}
+
+function generatedPairKeys(): StorageKeys {
+  return { write: [pairStorageKey], read: [pairStorageKey] };
+}
+
+// Generate the keys for the passport storage
+// The keys are generated based on the host and node configs
+// We need to keep backward compatibility with the legacy host cache
+// We support keeping cache when moving from host only to host/node
+// We do not support keeping cache when moving from host/node to host only
+function generatePassportKeys(config: ResolvedConfig): StorageKeys {
+  const write: string[] = [];
+  const read: string[] = [];
+
+  const writeKey = `OPTABLE_PASSPORT_${getWriteKeyBase64FromConfig(config)}`;
+
+  write.push(writeKey);
+  read.push(writeKey);
+
+  // Allows switching from host to host/node without losing cache
+  if (config.node) {
+    read.push(`OPTABLE_PASSPORT_${encodeBase64(`${config.host}`)}`);
+  }
+
+  // We keep `OPTABLE_PASS` keys for backward compatibility
+  // Once all clients are updated, we can remove them on next tag
+  if (config.legacyHostCache) {
+    read.push(`OPTABLE_PASSPORT_${encodeBase64(`${config.legacyHostCache}`)}`);
+    read.push(`OPTABLE_PASS_${encodeBase64(`${config.legacyHostCache}/${config.site}`)}`);
+  } else {
+    read.push(`OPTABLE_PASS_${encodeBase64(`${config.host}/${config.site}`)}`);
+  }
+
+  return { write, read };
+}
+
+export type { StorageKeys };
+export { generateSiteKeys, generatedPairKeys, generatePassportKeys, generateTargetingKeys };

--- a/lib/core/storage.test.js
+++ b/lib/core/storage.test.js
@@ -1,6 +1,6 @@
 import { DCN_DEFAULTS } from "../config";
 import crypto from "crypto";
-import LocalStorage, { deprecatedGenerateCacheKey, generateCacheKey, encodeBase64 } from "./storage";
+import LocalStorage from "./storage";
 
 function randomConfig() {
   const randomHex = crypto.randomBytes(8).toString("hex");
@@ -52,38 +52,6 @@ describe("LocalStorage", () => {
     expect(store.getSite()).toBeNull();
   });
 
-  test("reads from deprecated cache if new cache is empty but only writes to new cache", () => {
-    const config = randomConfig();
-    const store = new LocalStorage(config);
-    const deprecatedKey = `OPTABLE_PASS_${deprecatedGenerateCacheKey(config)}`;
-    const newKey = `OPTABLE_PASSPORT_${generateCacheKey(config)}`;
-
-    localStorage.setItem(deprecatedKey, "deprecated-value");
-    expect(store.getPassport()).toEqual("deprecated-value");
-
-    store.setPassport("new-value");
-    expect(store.getPassport()).toEqual("new-value");
-    expect(localStorage.getItem(newKey)).toEqual("new-value");
-    expect(localStorage.getItem(deprecatedKey)).toEqual("deprecated-value");
-
-    localStorage.removeItem(deprecatedKey);
-    localStorage.removeItem(newKey);
-  });
-
-  test("prioritizes new cache over deprecated cache", () => {
-    const config = randomConfig();
-    const store = new LocalStorage(config);
-    const deprecatedKey = `OPTABLE_PASS_${deprecatedGenerateCacheKey(config)}`;
-    const newKey = `OPTABLE_PASSPORT_${generateCacheKey(config)}`;
-
-    localStorage.setItem(deprecatedKey, "deprecated-value");
-    localStorage.setItem(newKey, "new-value");
-    expect(store.getPassport()).toEqual("new-value");
-
-    localStorage.removeItem(deprecatedKey);
-    localStorage.removeItem(newKey);
-  });
-
   test("persists pair ids from targeting responses", () => {
     const store = new LocalStorage(randomConfig());
     expect(
@@ -101,39 +69,5 @@ describe("LocalStorage", () => {
     );
     expect(store.storage.getItem("_optable_pairId")).toBe(btoa(JSON.stringify({ envelope: ["pair1", "pair2"] })));
     expect(store.getPairIDs()).toEqual(["pair1", "pair2"]);
-  });
-});
-
-describe("Cache Key Generation", () => {
-  const mockConfig = (overrides = {}) => ({
-    host: "example.com",
-    site: "test-site",
-    node: "node123",
-    legacyHostCache: "legacy.example.com",
-    ...overrides,
-  });
-
-  test("deprecatedGenerateCacheKey uses legacyHostCache if present", () => {
-    const config = mockConfig();
-    const expectedKey = encodeBase64(`${config.legacyHostCache}/${config.site}`);
-    expect(deprecatedGenerateCacheKey(config)).toEqual(expectedKey);
-  });
-
-  test("deprecatedGenerateCacheKey falls back to host if legacyHostCache is missing", () => {
-    const config = mockConfig({ legacyHostCache: undefined });
-    const expectedKey = encodeBase64(`${config.host}/${config.site}`);
-    expect(deprecatedGenerateCacheKey(config)).toEqual(expectedKey);
-  });
-
-  test("generateCacheKey uses host and node if node exists", () => {
-    const config = mockConfig();
-    const expectedKey = encodeBase64(`${config.host}/${config.node}`);
-    expect(generateCacheKey(config)).toEqual(expectedKey);
-  });
-
-  test("generateCacheKey falls back to host if node is missing", () => {
-    const config = mockConfig({ node: undefined });
-    const expectedKey = encodeBase64(config.host);
-    expect(generateCacheKey(config)).toEqual(expectedKey);
   });
 });

--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -2,7 +2,13 @@ import { SiteResponse } from "../edge/site";
 import type { ResolvedConfig } from "../config";
 import type { TargetingResponse } from "../edge/targeting";
 import { LocalStorageProxy } from "./regs/storage";
-import { generatedPairKeys, generatePassportKeys, generateSiteKeys, generateTargetingKeys, StorageKeys } from "./storage-keys";
+import {
+  generatedPairKeys,
+  generatePassportKeys,
+  generateSiteKeys,
+  generateTargetingKeys,
+  StorageKeys,
+} from "./storage-keys";
 
 const pairEIDSource = "pair-protocol.com";
 


### PR DESCRIPTION
**_Refactor:_** Moved storage key generation logic from LocalStorage to storage-keys file.

Refactored Functions: Consolidated key generation into generateSiteKeys, generateTargetingKeys, and generatePassportKeys for better organization.

Key Generation: Updated to handle host and node configurations.

Backward Compatibility: Ensured passport key logic supports legacy host cache.

Tests: Added unit tests for site, targeting, and passport key generation.

_**Changes:**_
Consolidated the key generation logic into a single location for easier maintenance and scalability.

Ensured that the passport key logic handles both node-based and non-node configurations properly.

**_Tests: Added tests to check:_**

**_Storage Key Generation_**
    ✓ generateSiteKeys should return correct storage keys (1 ms)
    ✓ generateTargetingKeys should return correct storage keys
    ✓ passport keys WITH NODE should write/read that first
    ✓ passport keys NO NODE should write/read that first
    ✓ passport keys NO LegacyHostCache doesn't use as read key