### PR TITLE
Don't disable gzip compression in GCS/CDN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,6 @@ jobs:
         with:
           path: "browser/dist/sdk.js"
           destination: "optable-web-sdk/${{ matrix.sdk-version }}"
-          gzip: false
           process_gcloudignore: false
           headers: |
             x-goog-meta-optable-sdk-version: ${{ github.ref_name }}


### PR DESCRIPTION
This removes the explicit disabling of gzip compression for the web-sdk bundle. It's unclear why it was disabled in the first place.