### PR TITLE
testing: Allow mocking IP to test features depending on IP resolution

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,8 @@ type InitConfig = {
   readOnly?: boolean;
   // Active experiments to test new features
   experiments?: Experiment[];
+  // Mock IP address for testing
+  mockedIP?: string;
 };
 
 type ResolvedConfig = {
@@ -41,6 +43,7 @@ type ResolvedConfig = {
   readOnly: boolean;
   legacyHostCache?: string;
   experiments: Experiment[];
+  mockedIP?: string;
 };
 
 const DCN_DEFAULTS = {
@@ -68,6 +71,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     node: init.node,
     legacyHostCache: init.legacyHostCache,
     experiments: init.experiments ?? DCN_DEFAULTS.experiments,
+    mockedIP: init.mockedIP,
   };
 
   if (init.consent?.static) {

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -44,6 +44,11 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   const requestInit: RequestInit = { ...init };
   requestInit.credentials = config.consent.deviceAccess ? "include" : "omit";
 
+  if (config.mockedIP) {
+    requestInit.headers = new Headers(requestInit.headers);
+    requestInit.headers.set("X-Forwarded-For", config.mockedIP);
+  }
+
   const request = new Request(url.toString(), requestInit);
 
   return request;


### PR DESCRIPTION
Allow mocking request IP when interacting with edge by accepting a `mockedIP` param in the config. When used `X-Forwarded-For` request header is set using this value.

This is meant to test various IP based functionalities and is not meant to be used in production.