### PR TITLE
Add a sid param to all calls

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -4,7 +4,7 @@ const defaultConsent = DCN_DEFAULTS.consent;
 
 describe("getConfig", () => {
   it("returns the default config when no overrides are provided", () => {
-    expect(getConfig({ host: "host", site: "site" })).toEqual({
+    expect(getConfig({ host: "host", site: "site", sessionID: "" })).toEqual({
       host: "host",
       site: "site",
       cookies: true,
@@ -12,6 +12,7 @@ describe("getConfig", () => {
       consent: defaultConsent,
       readOnly: false,
       experiments: [],
+      sessionID: "",
     });
   });
 
@@ -27,6 +28,7 @@ describe("getConfig", () => {
         node: "my-node",
         legacyHostCache: "legacy-cache",
         experiments: ["tokenize-v2"],
+        sessionID: "my-session-id",
       })
     ).toEqual({
       host: "host",
@@ -38,6 +40,7 @@ describe("getConfig", () => {
       node: "my-node",
       legacyHostCache: "legacy-cache",
       experiments: ["tokenize-v2"],
+      sessionID: "my-session-id",
     });
   });
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,8 @@ type InitConfig = {
   readOnly?: boolean;
   // Active experiments to test new features
   experiments?: Experiment[];
+  // Session ID to use, defaults to a random value
+  sessionID?: string;
 };
 
 type ResolvedConfig = {
@@ -41,6 +43,7 @@ type ResolvedConfig = {
   readOnly: boolean;
   legacyHostCache?: string;
   experiments: Experiment[];
+  sessionID: string;
 };
 
 const DCN_DEFAULTS = {
@@ -68,6 +71,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     node: init.node,
     legacyHostCache: init.legacyHostCache,
     experiments: init.experiments ?? DCN_DEFAULTS.experiments,
+    sessionID: init.sessionID ?? generateSessionID(),
   };
 
   if (init.consent?.static) {
@@ -79,5 +83,16 @@ function getConfig(init: InitConfig): ResolvedConfig {
   return config;
 }
 
+function generateSessionID(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+
+  // Equivalent to esnext arr.toBase64({ omitPadding: true, alphabet: "base64url" })
+  return btoa(String.fromCharCode(...arr))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
 export type { InitConsent, CMPApiConfig, InitConfig, ResolvedConfig };
-export { getConfig, DCN_DEFAULTS };
+export { getConfig, DCN_DEFAULTS, generateSessionID };

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -9,6 +9,7 @@ describe("buildRequest", () => {
       site: "site",
       node: "my-node",
       consent: { reg: "can", gpp: "gpp", gppSectionIDs: [1, 2] },
+      sessionID: "123",
     };
 
     const req = { method: "GET" };
@@ -21,6 +22,7 @@ describe("buildRequest", () => {
     expect([...url.searchParams.entries()]).toEqual([
       ["query", "string"],
       ["osdk", `web-${buildInfo.version}`],
+      ["sid", "123"],
       ["t", dcn.node],
       ["gpp", "gpp"],
       ["gpp_sid", "1,2"],

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -7,6 +7,7 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
 
   const url = new URL(`${site}${path}`, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
+  url.searchParams.set("sid", config.sessionID);
 
   if (config.node) {
     url.searchParams.set("t", config.node);

--- a/lib/edge/resolve.test.js
+++ b/lib/edge/resolve.test.js
@@ -4,21 +4,21 @@ import { parseResolveResponse, Resolve } from "./resolve";
 
 describe("resolve", () => {
   test("forwards identifier when present", () => {
-    const config = getConfig({ host: TEST_HOST, site: TEST_SITE });
+    const config = getConfig({ host: TEST_HOST, site: TEST_SITE, sessionID: "session" });
     const fetchSpy = jest.spyOn(window, "fetch");
 
     Resolve(config, "id");
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "GET",
-        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&cookies=yes`,
+        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&cookies=yes`,
       })
     );
 
     Resolve(config);
     expect.objectContaining({
       method: "GET",
-      url: `${TEST_BASE_URL}/v1/resolve?osdk=web-0.0.0-experimental&cookies=yes`,
+      url: `${TEST_BASE_URL}/v1/resolve?osdk=web-0.0.0-experimental&sid=session&cookies=yes`,
     });
   });
 });

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -60,6 +60,7 @@ describe("cid", () => {
 const defaultConfig = {
   host: TEST_HOST,
   site: TEST_SITE,
+  sessionID: "session",
 };
 
 describe("Breaking change detection: if typescript complains or a test fails it's likely a breaking change has occurred.", () => {
@@ -224,6 +225,7 @@ describe("behavior testing of", () => {
       initPassport: false,
       readOnly: false,
       experiments: [],
+      sessionID: "session",
     });
     await sdk["init"];
     expect(localStorage.setItem).toBeCalledTimes(0);
@@ -234,7 +236,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&cookies=no&passport=`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&cookies=no&passport=`,
       })
     );
 
@@ -244,7 +246,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f6"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&cookies=no&passport=PASSPORT`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&cookies=no&passport=PASSPORT`,
       })
     );
   });
@@ -263,6 +265,7 @@ describe("behavior testing of", () => {
       initPassport: true,
       readOnly: false,
       experiments: [],
+      sessionID: "session",
     });
     await sdk["init"];
     expect(window.localStorage.setItem).toHaveBeenLastCalledWith(
@@ -274,7 +277,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "GET",
         bodyUsed: false,
-        url: expect.stringContaining("config?osdk=web-0.0.0-experimental&cookies=yes"),
+        url: expect.stringContaining("config?osdk=web-0.0.0-experimental&sid=session&cookies=yes"),
       })
     );
 
@@ -284,7 +287,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&cookies=yes`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&cookies=yes`,
       })
     );
   });


### PR DESCRIPTION
Add a new `sid` param to all call to edge to allow tracking the number of calls per session or grouping calls that belongs together accross multiple SDK instances for reporting purpose.

The session ID can be input by the user when constructing the SDK or default to a urlsafe/omit padding base64'd random 16 bytes array.

The facility to generate a session ID is exposed to users in the config module.
