### PR TITLE
Add skip_enrichment url parameter

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -13,6 +13,7 @@ describe("getConfig", () => {
       readOnly: false,
       experiments: [],
       sessionID: "",
+      skipEnrichment: false,
     });
   });
 
@@ -29,6 +30,7 @@ describe("getConfig", () => {
         legacyHostCache: "legacy-cache",
         experiments: ["tokenize-v2"],
         sessionID: "my-session-id",
+        skipEnrichment: true,
       })
     ).toEqual({
       host: "host",
@@ -41,6 +43,7 @@ describe("getConfig", () => {
       legacyHostCache: "legacy-cache",
       experiments: ["tokenize-v2"],
       sessionID: "my-session-id",
+      skipEnrichment: true,
     });
   });
 

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -13,7 +13,7 @@ describe("getConfig", () => {
       readOnly: false,
       experiments: [],
       sessionID: "",
-      skipEnrichment: false,
+      skipEnrichment: undefined,
     });
   });
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -79,7 +79,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     experiments: init.experiments ?? DCN_DEFAULTS.experiments,
     mockedIP: init.mockedIP,
     sessionID: init.sessionID ?? generateSessionID(),
-    skipEnrichment: init.skipEnrichment ?? false,
+    skipEnrichment: init.skipEnrichment,
   };
 
   if (init.consent?.static) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -49,7 +49,7 @@ type ResolvedConfig = {
   experiments: Experiment[];
   mockedIP?: string;
   sessionID: string;
-  skipEnrichment: boolean;
+  skipEnrichment?: boolean;
 };
 
 const DCN_DEFAULTS = {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -33,6 +33,8 @@ type InitConfig = {
   mockedIP?: string;
   // Session ID to use, defaults to a random value
   sessionID?: string;
+  // Skip Enrichment
+  skipEnrichment?: boolean;
 };
 
 type ResolvedConfig = {
@@ -47,6 +49,7 @@ type ResolvedConfig = {
   experiments: Experiment[];
   mockedIP?: string;
   sessionID: string;
+  skipEnrichment: boolean;
 };
 
 const DCN_DEFAULTS = {
@@ -76,6 +79,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     experiments: init.experiments ?? DCN_DEFAULTS.experiments,
     mockedIP: init.mockedIP,
     sessionID: init.sessionID ?? generateSessionID(),
+    skipEnrichment: init.skipEnrichment ?? false,
   };
 
   if (init.consent?.static) {

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -10,6 +10,7 @@ describe("buildRequest", () => {
       node: "my-node",
       consent: { reg: "can", gpp: "gpp", gppSectionIDs: [1, 2] },
       sessionID: "123",
+      skipEnrichment: true,
     };
 
     const req = { method: "GET" };
@@ -23,6 +24,7 @@ describe("buildRequest", () => {
       ["query", "string"],
       ["osdk", `web-${buildInfo.version}`],
       ["sid", "123"],
+      ["skip_enrichment", "true"],
       ["t", dcn.node],
       ["o", dcn.site],
       ["gpp", "gpp"],

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -8,7 +8,10 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   const url = new URL(path, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
   url.searchParams.set("sid", config.sessionID);
-  url.searchParams.set("skip_enrichment", `${config.skipEnrichment}`);
+
+  if (config.skipEnrichment) {
+    url.searchParams.set("skip_enrichment", `${config.skipEnrichment}`);
+  }
 
   if (config.node) {
     url.searchParams.set("t", config.node);

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -8,6 +8,7 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
   const url = new URL(path, `https://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
   url.searchParams.set("sid", config.sessionID);
+  url.searchParams.set("skip_enrichment", `${config.skipEnrichment}`);
 
   if (config.node) {
     url.searchParams.set("t", config.node);

--- a/lib/edge/resolve.test.js
+++ b/lib/edge/resolve.test.js
@@ -11,7 +11,7 @@ describe("resolve", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "GET",
-        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&skip_enrichment=undefined&o=site&cookies=yes`,
+        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes`,
       })
     );
 

--- a/lib/edge/resolve.test.js
+++ b/lib/edge/resolve.test.js
@@ -11,7 +11,7 @@ describe("resolve", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "GET",
-        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes`,
+        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes`,
       })
     );
 

--- a/lib/edge/resolve.test.js
+++ b/lib/edge/resolve.test.js
@@ -11,7 +11,7 @@ describe("resolve", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "GET",
-        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes`,
+        url: `${TEST_BASE_URL}/v1/resolve?id=id&osdk=web-0.0.0-experimental&sid=session&skip_enrichment=undefined&o=site&cookies=yes`,
       })
     );
 

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -238,7 +238,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=no&passport=`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=no&passport=`,
       })
     );
 
@@ -248,7 +248,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f6"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=no&passport=PASSPORT`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=no&passport=PASSPORT`,
       })
     );
   });
@@ -281,7 +281,7 @@ describe("behavior testing of", () => {
         method: "GET",
         bodyUsed: false,
         url: expect.stringContaining(
-          "config?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes"
+          "config?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes"
         ),
       })
     );
@@ -292,7 +292,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes`,
       })
     );
   });

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -61,6 +61,7 @@ const defaultConfig = {
   host: TEST_HOST,
   site: TEST_SITE,
   sessionID: "session",
+  skipEnrichment: false,
 };
 
 describe("Breaking change detection: if typescript complains or a test fails it's likely a breaking change has occurred.", () => {
@@ -226,6 +227,7 @@ describe("behavior testing of", () => {
       readOnly: false,
       experiments: [],
       sessionID: "session",
+      skipEnrichment: false,
     });
     await sdk["init"];
     expect(localStorage.setItem).toBeCalledTimes(0);
@@ -236,7 +238,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=no&passport=`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=no&passport=`,
       })
     );
 
@@ -246,7 +248,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f6"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=no&passport=PASSPORT`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=no&passport=PASSPORT`,
       })
     );
   });
@@ -266,6 +268,7 @@ describe("behavior testing of", () => {
       readOnly: false,
       experiments: [],
       sessionID: "session",
+      skipEnrichment: false,
     });
     await sdk["init"];
     expect(window.localStorage.setItem).toHaveBeenLastCalledWith(
@@ -277,7 +280,9 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "GET",
         bodyUsed: false,
-        url: expect.stringContaining("config?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes"),
+        url: expect.stringContaining(
+          "config?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes"
+        ),
       })
     );
 
@@ -287,7 +292,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "POST",
         _bodyText: '["c:a1a335b8216658319f96a4b0c718557ba41dd1f5"]',
-        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes`,
+        url: `${TEST_BASE_URL}/identify?osdk=web-0.0.0-experimental&sid=session&skip_enrichment=false&o=site&cookies=yes`,
       })
     );
   });

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -280,9 +280,7 @@ describe("behavior testing of", () => {
       expect.objectContaining({
         method: "GET",
         bodyUsed: false,
-        url: expect.stringContaining(
-          "config?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes"
-        ),
+        url: expect.stringContaining("config?osdk=web-0.0.0-experimental&sid=session&o=site&cookies=yes"),
       })
     );
 


### PR DESCRIPTION
This PR introduces a new optional parameter `skip_enrichment` to all edge calls.

## Details
Adds a `skip_enrichment` flag to allow skipping cluster enrichment logic.

By default, `skip_enrichment` is set to false, meaning enrichment is performed as usual.

When `skip_enrichment=true` is passed, the enrichment step is bypassed.

## Motivation
This change provides more flexibility for consumers of the edge API by allowing them to opt out of enrichment logic when it's not needed.