### PR TITLE
SDK initialization when configs are present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,9 @@ If you want to avoid manually instantiating the SDK, you can define the `instanc
 
 ```html
 <!-- Define configuration before loading the SDK -->
-<script> window.optable = { cmd: [], instance_config: { host: "dcn.customer.com", site: "my-site" } }; </script>
+<script>
+  window.optable = { cmd: [], instance_config: { host: "dcn.customer.com", site: "my-site" } };
+</script>
 
 <!-- Asynchronously load the SDK -->
 <script async src="https://cdn.optable.co/web-sdk/v0/sdk.js"></script>
@@ -284,7 +286,9 @@ If you want to avoid manually instantiating the SDK, you can define the `instanc
   window.addEventListener("DOMContentLoaded", () => {
     optable.cmd.push(() => {
       const emailInput = document.getElementById("email");
-      optable.instance.identify(optable.SDK.eid(emailInput.value)).then(() => { console.log("Identify API Success!"); });
+      optable.instance.identify(optable.SDK.eid(emailInput.value)).then(() => {
+        console.log("Identify API Success!");
+      });
     });
   });
 </script>

--- a/browser/sdk.ts
+++ b/browser/sdk.ts
@@ -1,7 +1,7 @@
 import Commands from "./commands";
 import { resolveMultiNodeTargeting } from "../lib/core/resolvers/resolveMultiTargeting";
 
-import OptableSDK from "../lib/sdk";
+import OptableSDK, { InitConfig } from "../lib/sdk";
 import "../lib/addons/gpt";
 import "../lib/addons/try-identify";
 import "../lib/addons/paapi";
@@ -11,6 +11,8 @@ type OptableGlobal = {
   cmd: Commands | Function[];
   SDK: OptableSDK["constructor"];
   utils: Record<string, Function>;
+  instance?: OptableSDK;
+  instance_config?: InitConfig;
 };
 
 declare global {
@@ -26,3 +28,7 @@ window.optable = window.optable || {};
 window.optable.SDK = OptableSDK;
 window.optable.cmd = new Commands(window.optable.cmd || []);
 window.optable.utils = { resolveMultiNodeTargeting };
+
+if (window.optable.instance_config) {
+  window.optable.instance = new OptableSDK(window.optable.instance_config);
+}


### PR DESCRIPTION
**_Summary_**
This PR enables automatic SDK initialization when `window.optable.instance_config` is present on the client.

**_Use Case_**
To support async loading of the SDK bundle, the config is defined ahead of time. This allows the SDK to initialize automatically once the bundle loads:
```html
<script> window.optable = { instance_config: { host: "host.com", site: "some-source", node: "my-node" } } </script>
<script async src="https://cdn.optable.co/web-sdk/latest/sdk.js"></script>
```
When the SDK loads, it checks for `window.optable.instance_config` and instantiates `OptableSDK`, assigning the result to `window.optable.instance`.

**_Benefits_**
- Supports async script loading
- Simplifies integration with minimal setup
- Avoids manual SDK instantiation

