### PR TITLE
Add option to trigger targeting on initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,15 @@ When creating an instance of `OptableSDK`, you can pass an `InitConfig` object t
 - **`initPassport` (boolean, default: `true`)**
   If `true`, initializes the user passport (identity mechanism) upon SDK load.
 
+- **`initTargeting` (boolean, default: `false`)**
+  If `true`, the SDK will automatically perform a targeting request during initialization and store the response in cache. This ensures the cache is populated with the most up-to-date targeting data as soon as the SDK is loaded.
+
 - **`consent` (`InitConsent`)**
   Defines the consent settings for data collection and processing.
 
 - **`readOnly` (boolean, default: `false`)**
   When set to `true`, puts the SDK in a read-only mode, preventing any data modifications while still allowing API queries.
 
-- **`targetingOnLoad` (boolean, default: `false`)**  
-  If `true`, the SDK will automatically perform a targeting request during initialization and store the response in cache. This ensures the cache is populated with the most up-to-date targeting data as soon as the SDK is loaded.
 
 These configurations allow fine-tuned control over how the `OptableSDK` interacts with the Optable DCN, ensuring compatibility with different environments and privacy settings.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ When creating an instance of `OptableSDK`, you can pass an `InitConfig` object t
 - **`readOnly` (boolean, default: `false`)**
   When set to `true`, puts the SDK in a read-only mode, preventing any data modifications while still allowing API queries.
 
+- **`targetingOnLoad` (boolean, default: `false`)**  
+  If `true`, the SDK will automatically perform a targeting request during initialization and store the response in cache. This ensures the cache is populated with the most up-to-date targeting data as soon as the SDK is loaded.
+
 These configurations allow fine-tuned control over how the `OptableSDK` interacts with the Optable DCN, ensuring compatibility with different environments and privacy settings.
 
 ## Usage Example

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ When creating an instance of `OptableSDK`, you can pass an `InitConfig` object t
 - **`readOnly` (boolean, default: `false`)**
   When set to `true`, puts the SDK in a read-only mode, preventing any data modifications while still allowing API queries.
 
-
 These configurations allow fine-tuned control over how the `OptableSDK` interacts with the Optable DCN, ensuring compatibility with different environments and privacy settings.
 
 ## Usage Example

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -35,6 +35,8 @@ type InitConfig = {
   sessionID?: string;
   // Skip Enrichment
   skipEnrichment?: boolean;
+  // Targeting call on load
+  targetingOnLoad?: boolean;
 };
 
 type ResolvedConfig = {
@@ -50,6 +52,7 @@ type ResolvedConfig = {
   mockedIP?: string;
   sessionID: string;
   skipEnrichment?: boolean;
+  targetingOnLoad?: boolean;
 };
 
 const DCN_DEFAULTS = {
@@ -80,6 +83,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     mockedIP: init.mockedIP,
     sessionID: init.sessionID ?? generateSessionID(),
     skipEnrichment: init.skipEnrichment,
+    targetingOnLoad: init.targetingOnLoad,
   };
 
   if (init.consent?.static) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,7 +36,7 @@ type InitConfig = {
   // Skip Enrichment
   skipEnrichment?: boolean;
   // Targeting call on load
-  targetingOnLoad?: boolean;
+  initTargeting?: boolean;
 };
 
 type ResolvedConfig = {
@@ -52,7 +52,7 @@ type ResolvedConfig = {
   mockedIP?: string;
   sessionID: string;
   skipEnrichment?: boolean;
-  targetingOnLoad?: boolean;
+  initTargeting?: boolean;
 };
 
 const DCN_DEFAULTS = {
@@ -83,7 +83,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     mockedIP: init.mockedIP,
     sessionID: init.sessionID ?? generateSessionID(),
     skipEnrichment: init.skipEnrichment,
-    targetingOnLoad: init.targetingOnLoad,
+    initTargeting: init.initTargeting,
   };
 
   if (init.consent?.static) {

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -363,9 +363,9 @@ describe("behavior testing of", () => {
     );
   });
 
-  test("config has targetingOnLoad true then constructor sends a targeting request", async () => {
+  test("config has initTargeting true then constructor sends a targeting request", async () => {
     const fetchSpy = jest.spyOn(window, "fetch");
-    const sdk = new OptableSDK({ ...defaultConfig, targetingOnLoad: true });
+    const sdk = new OptableSDK({ ...defaultConfig, initPassport: false, initTargeting: true });
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -379,7 +379,6 @@ describe("behavior testing of", () => {
   test("targeting", async () => {
     const fetchSpy = jest.spyOn(window, "fetch");
     const sdk = new OptableSDK({ ...defaultConfig });
-
     const initialResultFromCache = sdk.targetingFromCache();
     expect(initialResultFromCache).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ url: expect.stringContaining("targeting") }));

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -2,6 +2,7 @@ import { SiteResponse } from "edge/site";
 import OptableSDK from "./sdk";
 import { TEST_BASE_URL, TEST_HOST, TEST_SITE } from "./test/mocks";
 import { DCN_DEFAULTS } from "./config";
+import { waitFor } from "./test/utils";
 
 const defaultConsent = DCN_DEFAULTS.consent;
 
@@ -360,6 +361,19 @@ describe("behavior testing of", () => {
         url: expect.stringContaining("witness"),
       })
     );
+  });
+
+  test("config has targetingOnLoad true then constructor sends a targeting request", async () => {
+    const fetchSpy = jest.spyOn(window, "fetch");
+    const sdk = new OptableSDK({ ...defaultConfig, targetingOnLoad: true });
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: expect.stringContaining("v2/targeting?id=__passport__"),
+        })
+      );
+    });
   });
 
   test("targeting", async () => {

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -31,6 +31,10 @@ class OptableSDK {
     // If initPassport, prefetch site config and cache it, it assigns a passport as a side effect
     const noop = () => {};
     this.init = this.dcn.initPassport ? Site(this.dcn).then(noop).catch(noop) : Promise.resolve();
+
+    if (this.dcn.targetingOnLoad) {
+      this.targeting();
+    }
   }
 
   async identify(...ids: string[]): Promise<void> {

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -28,12 +28,19 @@ class OptableSDK {
 
   constructor(dcn: InitConfig) {
     this.dcn = getConfig(dcn);
-    // If initPassport, prefetch site config and cache it, it assigns a passport as a side effect
-    const noop = () => {};
-    this.init = this.dcn.initPassport ? Site(this.dcn).then(noop).catch(noop) : Promise.resolve();
+    this.init = this.initialize();
+  }
 
-    if (this.dcn.targetingOnLoad) {
-      this.targeting();
+  async initialize(): Promise<void> {
+    try {
+      if (this.dcn.initPassport) {
+        await Site(this.dcn);
+      }
+
+      if (this.dcn.initTargeting) {
+        await this.targeting();
+      }
+    } catch { // ignore errors
     }
   }
 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -32,16 +32,12 @@ class OptableSDK {
   }
 
   async initialize(): Promise<void> {
-    try {
-      if (this.dcn.initPassport) {
-        await Site(this.dcn);
-      }
+    if (this.dcn.initPassport) {
+      await Site(this.dcn).catch(() => {});
+    }
 
-      if (this.dcn.initTargeting) {
-        await this.targeting();
-      }
-    } catch {
-      // ignore errors
+    if (this.dcn.initTargeting) {
+      this.targeting().catch(() => {});
     }
   }
 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -40,7 +40,8 @@ class OptableSDK {
       if (this.dcn.initTargeting) {
         await this.targeting();
       }
-    } catch { // ignore errors
+    } catch {
+      // ignore errors
     }
   }
 

--- a/lib/test/utils.ts
+++ b/lib/test/utils.ts
@@ -1,0 +1,18 @@
+// Helper function to wait for an assertion to pass
+// This is useful to test async code that may take some time to resolve
+export async function waitFor(assertion: () => void, timeout = 2000, interval = 50): Promise<void> {
+  const start = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      try {
+        assertion(); // attempt the expect()
+        resolve(); // passed, done!
+      } catch (err) {
+        if (Date.now() - start >= timeout) return reject(err); // timeout
+        setTimeout(check, interval); // retry
+      }
+    };
+    check();
+  });
+}


### PR DESCRIPTION
**_Summary_**
This PR adds a `initTargeting` config option. When enabled, the SDK will automatically run a targeting request during initialization, storing the result in cache.
This is done asynchronously to avoid slowing down initialization.

_**Use Case**_
This is useful when you want to proactively refresh the cache with the most up-to-date ORTB2 data. It’s especially valuable in scenarios involving bid enrichment, where having targeting data available as early as possible is critical.

_**Test**_
When`initTargeting`: true is set in the config, the SDK constructor triggers a targeting request automatically.