### PR TITLE
Add support for public cache key for targeting responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ When creating an instance of `OptableSDK`, you can pass an `InitConfig` object t
 
 - **`readOnly` (boolean, default: `false`)**
   When set to `true`, puts the SDK in a read-only mode, preventing any data modifications while still allowing API queries.
+- **`optableCacheTargeting` (string, defaults: `optable-cache:targeting`)**
+  Local storage cache key used to store latest targeting response.
 
 These configurations allow fine-tuned control over how the `OptableSDK` interacts with the Optable DCN, ensuring compatibility with different environments and privacy settings.
 

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -14,7 +14,7 @@ describe("getConfig", () => {
       experiments: [],
       sessionID: "",
       skipEnrichment: undefined,
-      optableCacheTargeting: "optable_cache_targeting",
+      optableCacheTargeting: "optable-cache:targeting",
     });
   });
 

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -14,6 +14,7 @@ describe("getConfig", () => {
       experiments: [],
       sessionID: "",
       skipEnrichment: undefined,
+      optableCacheTargeting: "optable_cache_targeting",
     });
   });
 
@@ -31,6 +32,7 @@ describe("getConfig", () => {
         experiments: ["tokenize-v2"],
         sessionID: "my-session-id",
         skipEnrichment: true,
+        optableCacheTargeting: "my-public-key",
       })
     ).toEqual({
       host: "host",
@@ -44,6 +46,7 @@ describe("getConfig", () => {
       experiments: ["tokenize-v2"],
       sessionID: "my-session-id",
       skipEnrichment: true,
+      optableCacheTargeting: "my-public-key",
     });
   });
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -37,12 +37,15 @@ type InitConfig = {
   skipEnrichment?: boolean;
   // Targeting call on load
   initTargeting?: boolean;
+  // (Defaults to 'optable_cache_targeting') Cache Key used to store 'targeting' response
+  optableCacheTargeting?: string;
 };
 
 type ResolvedConfig = {
   site: string;
   host: string;
   consent: Consent;
+  optableCacheTargeting: string;
   node?: string;
   cookies: boolean;
   initPassport: boolean;
@@ -73,6 +76,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
   const config: ResolvedConfig = {
     host: init.host,
     site: init.site,
+    optableCacheTargeting: init.optableCacheTargeting ?? "optable-cache:targeting",
     cookies: init.cookies ?? DCN_DEFAULTS.cookies,
     initPassport: init.initPassport ?? DCN_DEFAULTS.initPassport,
     consent: DCN_DEFAULTS.consent,

--- a/lib/core/storage-keys.test.js
+++ b/lib/core/storage-keys.test.js
@@ -6,7 +6,7 @@ describe("Storage Key Generation", () => {
     node: "node1",
     site: "site1",
     legacyHostCache: "legacy.example.com",
-    optableCacheTargeting: "optable_cache_targeting",
+    optableCacheTargeting: "optable-cache:targeting",
   };
 
   test("generateSiteKeys should return correct storage keys", () => {
@@ -26,13 +26,13 @@ describe("Storage Key Generation", () => {
   test("generateTargetingKeys should return correct storage keys", () => {
     const keysWithNodeConfig = generateTargetingKeys(mockConfig);
     expect(keysWithNodeConfig).toEqual({
-      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1"), "optable_cache_targeting"],
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1"), "optable-cache:targeting"],
       read: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
     });
 
     const keysWithoutNodeConfig = generateTargetingKeys({ ...mockConfig, node: undefined });
     expect(keysWithoutNodeConfig).toEqual({
-      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com"), "optable_cache_targeting"],
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com"), "optable-cache:targeting"],
       read: ["OPTABLE_TARGETING_" + encodeBase64("example.com")],
     });
   });

--- a/lib/core/storage-keys.test.js
+++ b/lib/core/storage-keys.test.js
@@ -6,6 +6,7 @@ describe("Storage Key Generation", () => {
     node: "node1",
     site: "site1",
     legacyHostCache: "legacy.example.com",
+    optableCacheTargeting: "optable_cache_targeting",
   };
 
   test("generateSiteKeys should return correct storage keys", () => {
@@ -25,14 +26,22 @@ describe("Storage Key Generation", () => {
   test("generateTargetingKeys should return correct storage keys", () => {
     const keysWithNodeConfig = generateTargetingKeys(mockConfig);
     expect(keysWithNodeConfig).toEqual({
-      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1"), "optable_cache_targeting"],
       read: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
     });
 
     const keysWithoutNodeConfig = generateTargetingKeys({ ...mockConfig, node: undefined });
     expect(keysWithoutNodeConfig).toEqual({
-      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com")],
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com"), "optable_cache_targeting"],
       read: ["OPTABLE_TARGETING_" + encodeBase64("example.com")],
+    });
+  });
+
+  test("generateTargetingKeys should write to publicKey set by init user override", () => {
+    const keysWithNodeConfig = generateTargetingKeys({ ...mockConfig, optableCacheTargeting: "my_public_key" });
+    expect(keysWithNodeConfig).toEqual({
+      write: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1"), "my_public_key"],
+      read: ["OPTABLE_TARGETING_" + encodeBase64("example.com/node1")],
     });
   });
 

--- a/lib/core/storage-keys.ts
+++ b/lib/core/storage-keys.ts
@@ -31,9 +31,10 @@ function generateSiteKeys(config: ResolvedConfig): StorageKeys {
 // Generate the keys for the targeting storage
 // The keys are generated based on the host and node configs
 function generateTargetingKeys(config: ResolvedConfig): StorageKeys {
-  const key = `OPTABLE_TARGETING_${getWriteKeyBase64FromConfig(config)}`;
+  const privateKey = `OPTABLE_TARGETING_${getWriteKeyBase64FromConfig(config)}`;
+  const publicKey = config.optableCacheTargeting;
 
-  return { write: [key], read: [key] };
+  return { write: [privateKey, publicKey], read: [privateKey] };
 }
 
 function generatedPairKeys(): StorageKeys {

--- a/lib/core/storage.test.js
+++ b/lib/core/storage.test.js
@@ -30,6 +30,13 @@ describe("LocalStorage", () => {
     expect(store.getTargeting()).toBeNull();
   });
 
+  test("targeting also writes to public key", () => {
+    const store = new LocalStorage({ ...randomConfig(), optableCacheTargeting: "my_public_key" });
+    expect(store.storage.getItem("my_public_key")).toBeNull();
+    store.setTargeting({ ortb2: { prop1: "some-value" } });
+    expect(store.storage.getItem("my_public_key")).toEqual(JSON.stringify({ ortb2: { prop1: "some-value" } }));
+  });
+
   test("allows to set targeting with empty value", () => {
     const store = new LocalStorage(randomConfig());
     expect(store.setTargeting());

--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -99,7 +99,7 @@ class LocalStorage {
   }
 
   clearStorageKeys(keys: StorageKeys): void {
-    for (const key of keys.read) {
+    for (const key of [...keys.read, ...keys.write]) {
       this.storage.removeItem(key);
     }
   }

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -229,7 +229,7 @@ describe("behavior testing of", () => {
       experiments: [],
       sessionID: "session",
       skipEnrichment: false,
-      optableCacheTargeting: "optable_cache_targeting",
+      optableCacheTargeting: "optable-cache:targeting",
     });
     await sdk["init"];
     expect(localStorage.setItem).toBeCalledTimes(0);
@@ -271,7 +271,7 @@ describe("behavior testing of", () => {
       experiments: [],
       sessionID: "session",
       skipEnrichment: false,
-      optableCacheTargeting: "optable_cache_targeting",
+      optableCacheTargeting: "optable-cache:targeting",
     });
     await sdk["init"];
     expect(window.localStorage.setItem).toHaveBeenLastCalledWith(

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -229,6 +229,7 @@ describe("behavior testing of", () => {
       experiments: [],
       sessionID: "session",
       skipEnrichment: false,
+      optableCacheTargeting: "optable_cache_targeting",
     });
     await sdk["init"];
     expect(localStorage.setItem).toBeCalledTimes(0);
@@ -270,6 +271,7 @@ describe("behavior testing of", () => {
       experiments: [],
       sessionID: "session",
       skipEnrichment: false,
+      optableCacheTargeting: "optable_cache_targeting",
     });
     await sdk["init"];
     expect(window.localStorage.setItem).toHaveBeenLastCalledWith(


### PR DESCRIPTION
This adds a new `optableCacheTargeting` config option to specify a public localStorage key for caching targeting responses.

- If set, the value is added to the list of write keys.
- Defaults to `optable-cache:targeting` if not provided.
- Enables clients to read from a known cache key without exposing internal ones.

Backwards compatible.