### PR TITLE
edge: Support targeting() multiple identifiers

### DIFF
--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -27,8 +27,8 @@ type TargetingResponse = {
   ortb2: { user: ortb2.User };
 };
 
-async function Targeting(config: ResolvedConfig, id: string): Promise<TargetingResponse> {
-  const searchParams = new URLSearchParams({ id });
+async function Targeting(config: ResolvedConfig, ...ids: readonly string[]): Promise<TargetingResponse> {
+  const searchParams = new URLSearchParams(ids.map((id) => ["id", id]));
   const path = "/v2/targeting?" + searchParams.toString();
 
   const response: TargetingResponse = await fetch(path, config, {

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -395,13 +395,13 @@ describe("behavior testing of", () => {
       })
     );
 
-    const targetingWithParam = await sdk.targeting("someId");
+    const targetingWithParam = await sdk.targeting("someId", "someOtherId");
     expect(targetingWithParam).toBeDefined();
 
     expect(fetchSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         method: "GET",
-        url: expect.stringContaining("v2/targeting?id=someId"),
+        url: expect.stringContaining("v2/targeting?id=someId&id=someOtherId"),
       })
     );
 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -54,9 +54,13 @@ class OptableSDK {
     return Uid2Token(this.dcn, id);
   }
 
-  async targeting(id: string = "__passport__"): Promise<TargetingResponse> {
+  async targeting(...ids: string[]): Promise<TargetingResponse> {
+    if (!ids.length) {
+      ids = ["__passport__"];
+    }
+
     await this.init;
-    return Targeting(this.dcn, id);
+    return Targeting(this.dcn, ...ids);
   }
 
   targetingFromCache(): TargetingResponse | null {


### PR DESCRIPTION
This updates `targeting()` to accept more than one identifier. Each will be passed as individual `id` query param which the server will resolves in order.