### PR TITLE
edge: Fix targeting to support cascading and start migrating toward object param

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,9 +1,7 @@
 import { getConsent, inferRegulation } from "./core/regs/consent";
 import type { CMPApiConfig, Consent } from "./core/regs/consent";
 
-type Experiment = |
-  "tokenize-v2" |
-  "targeting-cascade";
+type Experiment = "tokenize-v2" | "targeting-cascade";
 
 type InitConsent = {
   // A "cmpapi" configuration indicating that consent should be gathered from CMP apis.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,9 @@
 import { getConsent, inferRegulation } from "./core/regs/consent";
 import type { CMPApiConfig, Consent } from "./core/regs/consent";
 
-type Experiment = "tokenize-v2";
+type Experiment = |
+  "tokenize-v2" |
+  "targeting-cascade";
 
 type InitConsent = {
   // A "cmpapi" configuration indicating that consent should be gathered from CMP apis.

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -27,7 +27,7 @@ type TargetingResponse = {
   ortb2: { user: ortb2.User };
 };
 
-async function Targeting(config: ResolvedConfig, ...ids: readonly string[]): Promise<TargetingResponse> {
+async function Targeting(config: ResolvedConfig, ids: readonly string[]): Promise<TargetingResponse> {
   const searchParams = new URLSearchParams(ids.map((id) => ["id", id]));
   const path = "/v2/targeting?" + searchParams.toString();
 

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -395,8 +395,10 @@ describe("behavior testing of", () => {
       })
     );
 
-    const targetingWithParam = await sdk.targeting(["someId", "someOtherId"]);
-    expect(targetingWithParam).toBeDefined();
+    await expect(sdk.targeting({ ids: ["someId", "someOtherId"] })).rejects.toMatch(/targeting-cascade/)
+
+    sdk.dcn.experiments = ["targeting-cascade"];
+    const targetingWithParam = await sdk.targeting({ ids: ["someId", "someOtherId"] });
 
     expect(fetchSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -395,7 +395,7 @@ describe("behavior testing of", () => {
       })
     );
 
-    await expect(sdk.targeting({ ids: ["someId", "someOtherId"] })).rejects.toMatch(/targeting-cascade/)
+    await expect(sdk.targeting({ ids: ["someId", "someOtherId"] })).rejects.toMatch(/targeting-cascade/);
 
     sdk.dcn.experiments = ["targeting-cascade"];
     const targetingWithParam = await sdk.targeting({ ids: ["someId", "someOtherId"] });

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -395,7 +395,7 @@ describe("behavior testing of", () => {
       })
     );
 
-    const targetingWithParam = await sdk.targeting("someId", "someOtherId");
+    const targetingWithParam = await sdk.targeting(["someId", "someOtherId"]);
     expect(targetingWithParam).toBeDefined();
 
     expect(fetchSpy).toHaveBeenLastCalledWith(

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -23,8 +23,8 @@ import { Tokenize, TokenizeResponse } from "./edge/tokenize";
 type TargetingRequest =
   | string
   | {
-    ids?: string[];
-  };
+      ids?: string[];
+    };
 
 class OptableSDK {
   public static version = buildInfo.version;
@@ -39,11 +39,11 @@ class OptableSDK {
 
   async initialize(): Promise<void> {
     if (this.dcn.initPassport) {
-      await Site(this.dcn).catch(() => { });
+      await Site(this.dcn).catch(() => {});
     }
 
     if (this.dcn.initTargeting) {
-      this.targeting().catch(() => { });
+      this.targeting().catch(() => {});
     }
   }
 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -20,9 +20,11 @@ import { Profile } from "./edge/profile";
 import { sha256 } from "js-sha256";
 import { Tokenize, TokenizeResponse } from "./edge/tokenize";
 
-type TargetingRequest = string | {
-  ids?: string[];
-}
+type TargetingRequest =
+  | string
+  | {
+      ids?: string[];
+    };
 
 class OptableSDK {
   public static version = buildInfo.version;
@@ -37,11 +39,11 @@ class OptableSDK {
 
   async initialize(): Promise<void> {
     if (this.dcn.initPassport) {
-      await Site(this.dcn).catch(() => { });
+      await Site(this.dcn).catch(() => {});
     }
 
     if (this.dcn.initTargeting) {
-      this.targeting().catch(() => { });
+      this.targeting().catch(() => {});
     }
   }
 
@@ -59,10 +61,10 @@ class OptableSDK {
   }
 
   async targeting(request?: TargetingRequest = "__passport__"): Promise<TargetingResponse> {
-    const ids = typeof request === "string" ? [request] : (request?.ids || []);
+    const ids = typeof request === "string" ? [request] : request?.ids || [];
 
     if (ids.length > 1 && !this.dcn.experiments.includes("targeting-cascade")) {
-      throw "Targeting multiple IDs is only available with the 'targeting-cascade' experiment enabled."
+      throw "Targeting multiple IDs is only available with the 'targeting-cascade' experiment enabled.";
     }
 
     await this.init;

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -23,8 +23,8 @@ import { Tokenize, TokenizeResponse } from "./edge/tokenize";
 type TargetingRequest =
   | string
   | {
-      ids?: string[];
-    };
+    ids?: string[];
+  };
 
 class OptableSDK {
   public static version = buildInfo.version;
@@ -39,11 +39,11 @@ class OptableSDK {
 
   async initialize(): Promise<void> {
     if (this.dcn.initPassport) {
-      await Site(this.dcn).catch(() => {});
+      await Site(this.dcn).catch(() => { });
     }
 
     if (this.dcn.initTargeting) {
-      this.targeting().catch(() => {});
+      this.targeting().catch(() => { });
     }
   }
 
@@ -60,7 +60,7 @@ class OptableSDK {
     return Uid2Token(this.dcn, id);
   }
 
-  async targeting(request?: TargetingRequest = "__passport__"): Promise<TargetingResponse> {
+  async targeting(request: TargetingRequest = "__passport__"): Promise<TargetingResponse> {
     const ids = typeof request === "string" ? [request] : request?.ids || [];
 
     if (ids.length > 1 && !this.dcn.experiments.includes("targeting-cascade")) {

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -54,13 +54,11 @@ class OptableSDK {
     return Uid2Token(this.dcn, id);
   }
 
-  async targeting(...ids: string[]): Promise<TargetingResponse> {
-    if (!ids.length) {
-      ids = ["__passport__"];
-    }
+  async targeting(ids: string | string[] = "__passport__"): Promise<TargetingResponse> {
+    ids = Array.isArray(ids) ? ids : [ids];
 
     await this.init;
-    return Targeting(this.dcn, ...ids);
+    return Targeting(this.dcn, ids);
   }
 
   targetingFromCache(): TargetingResponse | null {


### PR DESCRIPTION
- Introduce a request for targeting instead of string only to allow supporting new features
- Introduce a new experiment "targeting-cascade" allowing to use cascade targeting through the object targeting request `ids`.

Passing multiple IDs is currently only allowed when the "targeting-cascade" experiment is passed.