### PR TITLE
Expose targeting resolved_ids in resolved event

### DIFF
--- a/lib/core/events/cache-refresh.test.ts
+++ b/lib/core/events/cache-refresh.test.ts
@@ -8,7 +8,7 @@ const mock_configs = {
 } as ResolvedConfig;
 
 const mock_response: TargetingResponse = {
-  resolved_id: "resolved-id",
+  resolved_ids: ["resolved-id"],
   ortb2: {
     user: {
       eids: [
@@ -34,7 +34,7 @@ describe("sendTargetingUpdateEvent", () => {
 
     expect(event.detail.instance).toBe("my-node");
     expect(event.detail.resolved).toBe(true);
-    expect(event.detail.resolvedID).toBe("resolved-id");
+    expect(event.detail.resolvedIDs).toEqual(["resolved-id"]);
     expect(event.detail.ortb2).toEqual(mock_response.ortb2);
     expect([...event.detail.provenance]).toEqual(["matcher-a", "matcher-b"]);
   });
@@ -80,12 +80,12 @@ describe("sendTargetingUpdateEvent", () => {
       });
     });
 
-    const { resolved_id: _ignore, ...response } = mock_response;
+    const { resolved_ids: _ignore, ...response } = mock_response;
 
     sendTargetingUpdateEvent(mock_configs, response);
 
     const event = await eventPromise;
 
-    expect(event.detail.resolvedID).toBeUndefined();
+    expect(event.detail.resolvedIDs).toEqual([]);
   });
 });

--- a/lib/core/events/cache-refresh.ts
+++ b/lib/core/events/cache-refresh.ts
@@ -11,7 +11,7 @@ function sendTargetingUpdateEvent(config: ResolvedConfig, response: TargetingRes
       detail: {
         instance: config.node || config.host,
         resolved: !!response.ortb2?.user?.eids?.length,
-        resolvedID: response.resolved_id,
+        resolvedIDs: response.resolved_ids ?? [],
         ortb2: response.ortb2,
         provenance: new Set(matchers),
       },

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -30,8 +30,8 @@ type TargetingResponse = {
   audience?: AudienceIdentifiers[];
   user?: UserIdentifiers[];
   ortb2: { user: ortb2.User };
-  // Identifier that matched and was used to generate the targeting response.
-  resolved_id?: string;
+  // Identifiers that matched and were used to generate the targeting response.
+  resolved_ids?: string[];
 };
 
 async function Targeting(config: ResolvedConfig, req: TargetingRequest): Promise<TargetingResponse> {


### PR DESCRIPTION
This updates the cache-refresh module to expose the upcoming resolved_ids field in targeting responses as `resolvedIDs string[]` which defaults to empty array.