### PR TITLE
use ref instead of url for clarity CU-86dxhr7zg

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -77,12 +77,12 @@ describe("getConfig", () => {
         site: "site",
         sessionID: "",
         additionalTargetingSignals: {
-          url: true,
+          ref: true,
         },
       });
 
       expect(config.additionalTargetingSignals).toEqual({
-        url: true,
+        ref: true,
       });
     });
 
@@ -92,12 +92,12 @@ describe("getConfig", () => {
         site: "site",
         sessionID: "",
         additionalTargetingSignals: {
-          url: false,
+          ref: false,
         },
       });
 
       expect(config.additionalTargetingSignals).toEqual({
-        url: false,
+        ref: false,
       });
     });
 
@@ -107,7 +107,7 @@ describe("getConfig", () => {
         site: "site",
         sessionID: "",
         additionalTargetingSignals: {
-          url: undefined,
+          ref: undefined,
         },
       });
 
@@ -135,12 +135,12 @@ describe("getConfig", () => {
         initPassport: false,
         readOnly: true,
         additionalTargetingSignals: {
-          url: true,
+          ref: true,
         },
       });
 
       expect(config.additionalTargetingSignals).toEqual({
-        url: true,
+        ref: true,
       });
       expect(config.cookies).toBe(false);
       expect(config.initPassport).toBe(false);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,7 +16,7 @@ type ABTestConfig = {
 
 type TargetingSignals = {
   // Include the current URL in the targeting call
-  url?: boolean;
+  ref?: boolean;
 };
 
 type InitConsent = {

--- a/lib/edge/targeting.test.js
+++ b/lib/edge/targeting.test.js
@@ -266,14 +266,14 @@ describe("Targeting function handles additionalTargetingSignals", () => {
     jest.clearAllMocks();
   });
 
-  test("includes URL parameter when additionalTargetingSignals.url is true", async () => {
+  test("includes Ref parameter when additionalTargetingSignals.ref is true", async () => {
     mockFetch.mockResolvedValue(createMockResponse({ audience: [], user: [] }));
 
     await Targeting(
       {
         ...baseConfig,
         additionalTargetingSignals: {
-          url: true,
+          ref: true,
         },
       },
       { ...baseReq }
@@ -282,20 +282,20 @@ describe("Targeting function handles additionalTargetingSignals", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       expect.objectContaining({
         url: expect.stringContaining(
-          "/v2/targeting?id=user123&hid=household456&url=https%3A%2F%2Fexample.com%2Ftest-page"
+          "/v2/targeting?id=user123&hid=household456&ref=https%3A%2F%2Fexample.com%2Ftest-page"
         ),
       })
     );
   });
 
-  test("does not include URL parameter when additionalTargetingSignals.url is false", async () => {
+  test("does not include Ref parameter when additionalTargetingSignals.ref is false", async () => {
     mockFetch.mockResolvedValue(createMockResponse({ audience: [], user: [] }));
 
     await Targeting(
       {
         ...baseConfig,
         additionalTargetingSignals: {
-          url: false,
+          ref: false,
         },
       },
       { ...baseReq }
@@ -303,7 +303,7 @@ describe("Targeting function handles additionalTargetingSignals", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.not.stringContaining("url="),
+        url: expect.not.stringContaining("ref="),
       })
     );
 
@@ -314,14 +314,14 @@ describe("Targeting function handles additionalTargetingSignals", () => {
     );
   });
 
-  test("does not include URL parameter when additionalTargetingSignals.url is undefined", async () => {
+  test("does not include Ref parameter when additionalTargetingSignals.ref is undefined", async () => {
     mockFetch.mockResolvedValue(createMockResponse({ audience: [], user: [] }));
 
     await Targeting(
       {
         ...baseConfig,
         additionalTargetingSignals: {
-          url: undefined,
+          ref: undefined,
         },
       },
       { ...baseReq }
@@ -335,12 +335,12 @@ describe("Targeting function handles additionalTargetingSignals", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.not.stringContaining("url="),
+        url: expect.not.stringContaining("ref="),
       })
     );
   });
 
-  test("does not include URL parameter when additionalTargetingSignals is not provided", async () => {
+  test("does not include Ref parameter when additionalTargetingSignals is not provided", async () => {
     mockFetch.mockResolvedValue(createMockResponse({ audience: [], user: [] }));
 
     await Targeting(
@@ -359,12 +359,12 @@ describe("Targeting function handles additionalTargetingSignals", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.not.stringContaining("url="),
+        url: expect.not.stringContaining("ref="),
       })
     );
   });
 
-  test("correctly encodes URL with special characters", async () => {
+  test("correctly encodes Ref with special characters", async () => {
     // Mock window.location with special characters
     global.window.location = {
       protocol: "https:",
@@ -377,7 +377,7 @@ describe("Targeting function handles additionalTargetingSignals", () => {
       {
         ...baseConfig,
         additionalTargetingSignals: {
-          url: true,
+          ref: true,
         },
       },
       { ...baseReq }
@@ -385,7 +385,7 @@ describe("Targeting function handles additionalTargetingSignals", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.stringContaining("url=https%3A%2F%2Fexample.com%2Fpath+with+spaces%2Fand%26special%3Dchars"),
+        url: expect.stringContaining("ref=https%3A%2F%2Fexample.com%2Fpath+with+spaces%2Fand%26special%3Dchars"),
       })
     );
   });

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -75,8 +75,8 @@ async function Targeting(config: ResolvedConfig, req: TargetingRequest): Promise
     }
   }
 
-  if (config.additionalTargetingSignals?.url) {
-    searchParams.append("url", `${window.location.protocol}//${window.location.host}${window.location.pathname}`);
+  if (config.additionalTargetingSignals?.ref) {
+    searchParams.append("ref", `${window.location.protocol}//${window.location.host}${window.location.pathname}`);
   }
 
   const path = "/v2/targeting?" + searchParams.toString();


### PR DESCRIPTION
## Why this change?

Refactoring the targeting configuration parameter from `url` to `ref` for better semantic clarity and consistency.

## What is changed?

- Service: Optable Web SDK
  - Areas:
    - Configuration system
    - Edge targeting functionality
    - Test suite

The change renames the `additionalTargetingSignals.url` parameter to `additionalTargetingSignals.ref` throughout the codebase. This affects:

- Configuration type definitions in `lib/config.ts`
- Edge targeting implementation in `lib/edge/targeting.ts`
- All related test files (`lib/config.test.ts`, `lib/edge/targeting.test.js`)

The functionality remains identical - the parameter still captures the current page URL/reference for targeting purposes. 

[The change has been made an approved in edge already.](https://github.com/Optable/optable-sandbox/pull/11312)

## How to test the changes?

**Automated tests:**
- Configuration tests in `lib/config.test.ts` verify the new `ref` parameter works correctly
- Targeting tests in `lib/edge/targeting.test.js` ensure the ref parameter is properly included/excluded based on configuration
- Tests cover all scenarios: `ref: true`, `ref: false`, `ref: undefined`, and when not provided

**Manual testing:**
The change is simple enough, well covered by tests.

## Dependency changes?

- [x] No