### PR TITLE
Add AB Test label name to js event response

### DIFF
--- a/lib/core/events/cache-refresh.ts
+++ b/lib/core/events/cache-refresh.ts
@@ -12,6 +12,7 @@ function sendTargetingUpdateEvent(config: ResolvedConfig, response: TargetingRes
         instance: config.node || config.host,
         resolved: !!response.ortb2?.user?.eids?.length,
         resolvedIDs: response.resolved_ids ?? [],
+        abTestID: response.ab_test_label ?? undefined,
         ortb2: response.ortb2,
         provenance: new Set(matchers),
       },

--- a/lib/core/events/cache-refresh.ts
+++ b/lib/core/events/cache-refresh.ts
@@ -12,7 +12,7 @@ function sendTargetingUpdateEvent(config: ResolvedConfig, response: TargetingRes
         instance: config.node || config.host,
         resolved: !!response.ortb2?.user?.eids?.length,
         resolvedIDs: response.resolved_ids ?? [],
-        abTestID: response.ab_test_label ?? undefined,
+        abTestID: response.ab_test_id ?? undefined,
         ortb2: response.ortb2,
         provenance: new Set(matchers),
       },

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -34,8 +34,8 @@ type TargetingResponse = {
   refs?: Record<string, unknown>;
   // Identifiers that matched and were used to generate the targeting response.
   resolved_ids?: string[];
-  // A/B test label
-  ab_test_label?: string;
+  // A/B test ID
+  ab_test_id?: string;
 };
 
 // Determine which A/B test (if any) should be used for this request

--- a/lib/edge/targeting.ts
+++ b/lib/edge/targeting.ts
@@ -34,6 +34,8 @@ type TargetingResponse = {
   refs?: Record<string, unknown>;
   // Identifiers that matched and were used to generate the targeting response.
   resolved_ids?: string[];
+  // A/B test label
+  ab_test_label?: string;
 };
 
 // Determine which A/B test (if any) should be used for this request


### PR DESCRIPTION
But I think we should align on one naming, either **ab_test_id** or **ab_test_label** across the board.