### PR TITLE
Support passing timeout param for all edge calls

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -59,6 +59,10 @@ type InitConfig = {
   abTests?: ABTestConfig[];
   // Additional targeting signals to pass to the targeting call
   additionalTargetingSignals?: TargetingSignals;
+  // Timeout hint for API calls (must include unit, e.g. '100ms', '2s', '1m')
+  // When provided, the server will attempt to answer within the given time limit.
+  // Some APIs like targeting may return partial responses depending at which stage the timeout occurred.
+  timeout?: string;
 };
 
 type ResolvedConfig = {
@@ -78,6 +82,7 @@ type ResolvedConfig = {
   initTargeting?: boolean;
   abTests?: ABTestConfig[];
   additionalTargetingSignals?: TargetingSignals;
+  timeout?: string;
 };
 
 const DCN_DEFAULTS = {
@@ -112,6 +117,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     initTargeting: init.initTargeting,
     abTests: init.abTests,
     additionalTargetingSignals: init.additionalTargetingSignals,
+    timeout: init.timeout,
   };
 
   if (init.consent?.static) {

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -41,6 +41,10 @@ function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit):
     url.searchParams.set("ro", "true");
   }
 
+  if (config.timeout) {
+    url.searchParams.set("timeout", config.timeout);
+  }
+
   if (cookies) {
     url.searchParams.set("cookies", "yes");
   } else {

--- a/lib/sdk.test.ts
+++ b/lib/sdk.test.ts
@@ -485,6 +485,18 @@ describe("behavior testing of", () => {
       })
     );
   });
+
+  test("supports passing a timeout to edge calls", async () => {
+    const fetchSpy = jest.spyOn(window, "fetch");
+    const sdk = new OptableSDK({ ...defaultConfig, timeout: "30ms" });
+    await sdk.targeting("someId");
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining("&timeout=30ms"),
+      })
+    );
+  });
 });
 
 describe("normalizeTargetingRequest", () => {


### PR DESCRIPTION
This adds a new `timeout` config allowing to pass the timeout hint to all edge calls.