### PR TITLE
Upgrade Node.js to 24.3

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -8,13 +8,9 @@ backend = "aqua:FiloSottile/mkcert"
 "platforms.windows-x64" = { url = "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe"}
 
 [[tools.node]]
-version = "22.12.0"
+version = "24.3.0"
 backend = "core:node"
-"platforms.linux-arm64" = { checksum = "sha256:9e7905fdee722f9650a03ae644b51c4c6effd3b98ac93c588700072ab35c9ddb", url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-arm64.tar.gz"}
-"platforms.linux-x64" = { checksum = "sha256:e05a4d65232ae2b27b3d77da2e368522fb46b923335b8e0d5f77624c32484044", url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.gz"}
-"platforms.macos-arm64" = { checksum = "sha256:293dcc6c2408da21562d135b0412525e381bb6fe150d688edb58fe850d0f3e13", url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-darwin-arm64.tar.gz"}
-"platforms.macos-x64" = { checksum = "sha256:52bc25dd026db7247c3c00439afdb83e95087248267f02d6c1a7250d1f896173", url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-darwin-x64.tar.gz"}
-"platforms.windows-x64" = { checksum = "sha256:2b8f2256382f97ad51e29ff71f702961af466c4616393f767455501e6aece9b8", url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-win-x64.zip"}
+"platforms.macos-arm64" = { checksum = "sha256:fee91aa5febeda47ef9f6c0afd2f2bcd3dacb0e656c29de0b5274e0ea1ca3565", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-darwin-arm64.tar.gz"}
 
 [[tools.pnpm]]
 version = "10.11.0"

--- a/mise.lock
+++ b/mise.lock
@@ -10,7 +10,11 @@ backend = "aqua:FiloSottile/mkcert"
 [[tools.node]]
 version = "24.3.0"
 backend = "core:node"
+"platforms.linux-arm64" = { checksum = "sha256:371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-linux-arm64.tar.gz"}
+"platforms.linux-x64" = { checksum = "sha256:bbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-linux-x64.tar.gz"}
 "platforms.macos-arm64" = { checksum = "sha256:fee91aa5febeda47ef9f6c0afd2f2bcd3dacb0e656c29de0b5274e0ea1ca3565", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-darwin-arm64.tar.gz"}
+"platforms.macos-x64" = { checksum = "sha256:0c065ffa4e53b1a172ab9cd8ca08ae141b187aca8a07403c6856a7b8d0024804", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-darwin-x64.tar.gz"}
+"platforms.windows-x64" = { checksum = "sha256:c0c8efbca1b57e5b074bbdf7cef1ccca40979d6b46e5bcadaad5d4b07cbb3b10", url = "https://nodejs.org/dist/v24.3.0/node-v24.3.0-win-x64.zip"}
 
 [[tools.pnpm]]
 version = "10.11.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "22.12.0"
+node = "24.3.0"
 pnpm = "10.11.0"
 mkcert = "1.4.4"
 semver = "3.3.0"


### PR DESCRIPTION
Required to use `npm` OIDC feature for publishing web-sdk release