### PR TITLE
Template and validation for new Web SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,31 @@ jobs:
           headers: |
             x-goog-meta-optable-sdk-version: ${{ github.ref_name }}
 
+  deploy-pub-template-to-gcs:
+    needs: [build]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Auth to google cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.workload_identity_provider }}
+          service_account: ${{ env.service-account }}
+
+      - name: Upload pub.ts template to GCS bucket
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "browser/pub.ts"
+          destination: "optable-web-sdk/pub-sdk/${{ github.ref_name }}"
+          process_gcloudignore: false
+          headers: |
+            x-goog-meta-optable-sdk-version: ${{ github.ref_name }}
+
   deploy-demo:
     needs: [deploy-sdk-to-npm]
     permissions:
@@ -181,7 +206,7 @@ jobs:
         run: docker push us-docker.pkg.dev/optable-artifact-registry/optable/optable-web-sdk-demos:${{ github.ref_name }}
 
   slack-notification:
-    needs: [tests-prettier, build, deploy-sdk-to-npm, define-gcs-versions-to-update, deploy-sdk-to-gcs, deploy-demo]
+    needs: [tests-prettier, build, deploy-sdk-to-npm, define-gcs-versions-to-update, deploy-sdk-to-gcs, deploy-pub-template-to-gcs, deploy-demo]
     runs-on: ubuntu-22.04
     if: ${{ failure() }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,10 @@ jobs:
             x-goog-meta-optable-sdk-version: ${{ github.ref_name }}
 
   deploy-pub-template-to-gcs:
-    needs: [build]
+    needs: [deploy-sdk-to-npm, define-gcs-versions-to-update]
+    strategy:
+      matrix:
+        sdk-version: ${{ fromJSON(needs.define-gcs-versions-to-update.outputs.sdk-versions) }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -143,7 +146,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "browser/pub.ts"
-          destination: "optable-web-sdk/pub-sdk/${{ github.ref_name }}"
+          destination: "optable-web-sdk/pub-sdk/${{ matrix.sdk-version }}"
           process_gcloudignore: false
           headers: |
             x-goog-meta-optable-sdk-version: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,16 @@ jobs:
         run: docker push us-docker.pkg.dev/optable-artifact-registry/optable/optable-web-sdk-demos:${{ github.ref_name }}
 
   slack-notification:
-    needs: [tests-prettier, build, deploy-sdk-to-npm, define-gcs-versions-to-update, deploy-sdk-to-gcs, deploy-pub-template-to-gcs, deploy-demo]
+    needs:
+      [
+        tests-prettier,
+        build,
+        deploy-sdk-to-npm,
+        define-gcs-versions-to-update,
+        deploy-sdk-to-gcs,
+        deploy-pub-template-to-gcs,
+        deploy-demo,
+      ]
     runs-on: ubuntu-22.04
     if: ${{ failure() }}
     steps:

--- a/.github/workflows/reusable-lint-test.yml
+++ b/.github/workflows/reusable-lint-test.yml
@@ -14,6 +14,27 @@ jobs:
       - name: Test
         run: pnpm test
 
+  validate-pub-template:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if pub template files changed
+        id: changed
+        run: |
+          if git diff --name-only origin/master...HEAD | grep -qE '^(browser/pub\.ts|scripts/validate-pub-template\.sh)$'; then
+            echo "pub_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pub_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate pub.ts template
+        if: steps.changed.outputs.pub_changed == 'true'
+        run: ./scripts/validate-pub-template.sh
+
   prettier:
     runs-on: ubuntu-22.04
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,9 @@
 
 # build outputs
 browser/dist
+
+# Go text/template file (not valid TypeScript)
+browser/pub.ts
 lib/dist
 
 # demos

--- a/browser/pub.ts
+++ b/browser/pub.ts
@@ -8,6 +8,8 @@
 //   .Node              - Node slug derived from tenant
 //   .Timeout           - Optional timeout hint (e.g. "500ms", "2s")
 //   .PrebidGlobal      - Prebid.js global variable name (e.g. "pbjs", "__pmc_atlasmg_pbjs")
+//   .TcfeuVendorID        - Optional TCF EU vendor ID (GVLID) for consent checks
+//   .TcfcaVendorID        - Optional TCF CA vendor ID (GVLID) for consent checks
 //   .EnableSecureSignals  - Boolean: enable GPT Secure Signals
 //   .EnableBotDetection   - Boolean: enable bot detection
 //   .EnableAnalytics      - Boolean: enable Prebid analytics
@@ -67,7 +69,14 @@ function getConsent() {
       useProfilesForAdvertising: true,
     };
   }
-  return { cmpapi: {} };
+  return { cmpapi: {
+    {{- if .TcfeuVendorID}}
+    tcfeuVendorID: {{.TcfeuVendorID}},
+    {{- end}}
+    {{- if .TcfcaVendorID}}
+    tcfcaVendorID: {{.TcfcaVendorID}},
+    {{- end}}
+  } };
 }
 
 {{if .EnableAnalytics}}

--- a/browser/pub.ts
+++ b/browser/pub.ts
@@ -1,0 +1,141 @@
+// browser/pub.ts — Go text/template + TypeScript
+// This file is processed by Go text/template BEFORE esbuild compilation.
+// It is NOT valid TypeScript until template directives are resolved.
+//
+// Template variables:
+//   .Host              - Edge API hostname (e.g. "ca.edge.optable.co")
+//   .Site              - Site slug derived from origin
+//   .Node              - Node slug derived from tenant
+//   .Timeout           - Optional timeout hint (e.g. "500ms", "2s")
+//   .PrebidGlobal      - Prebid.js global variable name (e.g. "pbjs", "__pmc_atlasmg_pbjs")
+//   .EnableSecureSignals  - Boolean: enable GPT Secure Signals
+//   .EnableBotDetection   - Boolean: enable bot detection
+//   .EnableAnalytics      - Boolean: enable Prebid analytics
+//   .GeoTargeting         - "regional" or "multi-region"
+
+import OptableSDK from "@optable/web-sdk";
+{{if .EnableAnalytics}}
+import OptablePrebidAnalytics from "@optable/web-sdk/lib/dist/addons/prebid/analytics";
+{{end}}
+
+declare global {
+  interface Window {
+    optable?: Record<string, any>;
+  }
+}
+
+// --- Commands queue (executes queued functions immediately) ---
+class OptableCommands {
+  constructor(cmds: OptableCommands | Function[]) {
+    if (Array.isArray(cmds)) {
+      for (const cmd of cmds) {
+        if (typeof cmd === "function") cmd();
+      }
+    }
+  }
+  push(cmd: Function) {
+    cmd();
+  }
+}
+
+// --- Debug logging ---
+function optableMessage(...args: unknown[]) {
+  if (sessionStorage.optableDebug) {
+    console.log("[OPTABLE WRAPPER]", ...args);
+  }
+}
+
+// --- URL query feature flags ---
+function setOptableFlagsFromURLQuery() {
+  const keys = ["optableDebug", "optableDisableConsent", "optableResolveTD", "optableEnableAnalytics"];
+  const search = window.location.search || "";
+  keys.forEach((key) => {
+    if (search.match(new RegExp(key, "g"))) {
+      sessionStorage.setItem(key, "1");
+    }
+  });
+}
+
+// --- Consent handling ---
+function getConsent() {
+  if (sessionStorage.optableDisableConsent) {
+    return {
+      createProfilesForAdvertising: true,
+      deviceAccess: true,
+      measureAdvertisingPerformance: true,
+      reg: null,
+      useProfilesForAdvertising: true,
+    };
+  }
+  return { cmpapi: {} };
+}
+
+{{if .EnableAnalytics}}
+// --- Analytics initialization ---
+function initPrebidAnalytics(sdk: OptableSDK) {
+  const pbjsObject = (window as any)["{{.PrebidGlobal}}"] || (window as any)["pbjs"];
+  if (!pbjsObject) return;
+
+  const analyticsSDK = new OptableSDK({
+    host: "{{.Host}}",
+    node: "analytics",
+    site: "analytics",
+    readOnly: true,
+    cookies: false,
+  });
+
+  const analytics = new OptablePrebidAnalytics(analyticsSDK, {
+    analytics: true,
+    tenant: "{{.Node}}",
+    debug: !!sessionStorage.optableDebug,
+    samplingRate: 0.1,
+  });
+
+  analytics.hookIntoPrebid(pbjsObject);
+}
+{{end}}
+
+// --- Main execution ---
+(function run() {
+  setOptableFlagsFromURLQuery();
+
+  window.optable = window.optable || {};
+  window.optable.SDK = OptableSDK;
+
+  const consent = getConsent();
+  const sdk = new OptableSDK({
+    host: "{{.Host}}",
+    site: "{{.Site}}",
+    node: "{{.Node}}",
+    cookies: false,
+    consent,
+    initPassport: false,
+    {{- if .Timeout}}
+    timeout: "{{.Timeout}}",
+    {{- end}}
+  });
+
+  window.optable["{{.Node}}_instance"] = sdk;
+
+  {{if .EnableSecureSignals}}
+  optableMessage("Enabling secure signals");
+  sdk.installGPTSecureSignals();
+  {{end}}
+
+  {{if .EnableBotDetection}}
+  optableMessage("Enabling bot detection");
+  (sdk as any).enableBotDetection();
+  {{end}}
+
+  {{if eq .GeoTargeting "multi-region"}}
+  optableMessage("Multi-region mode: reading window.optable.countryCode");
+  (sdk as any).setCountryCodeFromGlobal();
+  {{end}}
+
+  {{if .EnableAnalytics}}
+  initPrebidAnalytics(sdk);
+  {{end}}
+
+  window.optable.cmd = new OptableCommands(window.optable.cmd || []);
+  optableMessage("SDK initialized");
+})();

--- a/scripts/validate-pub-template.sh
+++ b/scripts/validate-pub-template.sh
@@ -30,6 +30,8 @@ sed \
   -e 's/{{\.Node}}/sample-node/g' \
   -e 's/{{\.PrebidGlobal}}/pbjs/g' \
   -e 's/{{\.Timeout}}/500ms/g' \
+  -e 's/{{\.TcfeuVendorID}}/123/g' \
+  -e 's/{{\.TcfcaVendorID}}/456/g' \
   "${TEMPLATE}" > "${rendered}"
 
 echo "Rendered template to ${rendered}"

--- a/scripts/validate-pub-template.sh
+++ b/scripts/validate-pub-template.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Validates that browser/pub.ts renders to compilable TypeScript.
+#
+# This script simulates Go text/template rendering by replacing template
+# directives with sample values, then compiles the result with esbuild
+# to catch syntax errors before they reach a release.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEMPLATE="${REPO_ROOT}/browser/pub.ts"
+WORKDIR="$(mktemp -d)"
+
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+echo "Validating pub.ts template..."
+
+# Render template with sample config values.
+# Features that depend on SDK methods not yet implemented are disabled.
+rendered="${WORKDIR}/pub.ts"
+
+sed \
+  -e '/{{if/d' \
+  -e '/{{end}}/d' \
+  -e 's/{{- if [^}]*}}//' \
+  -e 's/{{- end}}//' \
+  -e 's/{{\.Host}}/sample.edge.example.co/g' \
+  -e 's/{{\.Site}}/sample-site/g' \
+  -e 's/{{\.Node}}/sample-node/g' \
+  -e 's/{{\.PrebidGlobal}}/pbjs/g' \
+  -e 's/{{\.Timeout}}/500ms/g' \
+  "${TEMPLATE}" > "${rendered}"
+
+echo "Rendered template to ${rendered}"
+
+# Compile with esbuild to verify the output is valid TypeScript.
+# @optable/web-sdk is marked external since it's resolved at bundle time (Phase 5).
+npx --yes esbuild "${rendered}" \
+  --bundle \
+  --format=iife \
+  --platform=browser \
+  --target=es2015 \
+  --external:@optable/web-sdk \
+  --external:@optable/web-sdk/* \
+  --outfile="${WORKDIR}/pub.js"
+
+echo "Template validation passed: pub.ts renders to compilable TypeScript."


### PR DESCRIPTION
ClickUp Task ID:

## Why

Phase 2 of the configurable SDK bundler pipeline. This adds the Go `text/template` file that the Temporal worker will render per-tenant and compile with esbuild, replacing hand-crafted bundles in `optable-solutions/sdk-bundles/`.

## What Changed

- **`browser/pub.ts`**: Go `text/template` + TypeScript template with config directives (`Host`, `Site`, `Node`, `Timeout`, `PrebidGlobal`, `TcfeuVendorID`, `TcfcaVendorID`) and conditional blocks (`EnableAnalytics`, `EnableSecureSignals`, `EnableBotDetection`, `GeoTargeting`).
- **CI release**: New `deploy-pub-template-to-gcs` job uploads `pub.ts` to `gs://optable-web-sdk/pub-sdk/{version}/pub.ts` using the same version matrix as the SDK.
- **CI validation**: New `validate-pub-template` job in `reusable-lint-test.yml` renders the template with sample values and compiles with esbuild. Only runs when `pub.ts` or the validation script changes.
- **`.prettierignore`**: Excludes `browser/pub.ts` (Go template directives aren't valid TypeScript).

## How to Test

- [ ] `./scripts/validate-pub-template.sh` passes locally
- [ ] CI `validate-pub-template` job passes on PR
- [ ] On release tag: `pub.ts` appears at `gs://optable-web-sdk/pub-sdk/v{tag}/pub.ts`

## Notes

- `pub.ts` is NOT valid TypeScript, it becomes valid only after Go template rendering (Phase 5).
- Analytics uses a hardcoded 10% sampling rate per design doc.
- `browser/tsconfig.json` already excludes `pub.ts` (uses `"files": ["sdk.ts"]`).
- **SDK methods not yet implemented (tracked in Phase 5):**
  - `installGPTSecureSignals()` called with no args is currently a no-op, the SDK needs a no-arg auto-enable variant before `EnableSecureSignals` can be turned on.
  - `enableBotDetection()` and `setCountryCodeFromGlobal()` don't exist on the SDK yet, they're behind conditional blocks and cast to `any`.
  - The prebid analytics addon references `SDK_WRAPPER_VERSION`, Phase 3's esbuild config must define this value or the bundle will throw at runtime.