### PR TITLE
fix(analytics/prebid): accumulate all bidWon events before emitting witness

### DIFF
--- a/lib/addons/prebid/analytics.test.ts
+++ b/lib/addons/prebid/analytics.test.ts
@@ -191,7 +191,7 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 1.5,
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, bidWonEvent);
+      const result = await analytics.toWitness(auctionEndEvent, [bidWonEvent]);
 
       expect(result).toMatchObject({
         auctionId: "auction-123",
@@ -205,7 +205,8 @@ describe("OptablePrebidAnalytics", () => {
         missed: false,
       });
 
-      expect(result.bidWon).toMatchObject({
+      expect(result.bidWon).toHaveLength(1);
+      expect(result.bidWon[0]).toMatchObject({
         bidderCode: "bidder1",
         adUnitCode: "ad-unit-1",
       });
@@ -249,7 +250,7 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 2.0,
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, bidWonEvent);
+      const result = await analytics.toWitness(auctionEndEvent, [bidWonEvent]);
 
       expect(result.optableMatchers).toEqual([]);
       expect(result.optableSources).toEqual([]);
@@ -289,6 +290,7 @@ describe("OptablePrebidAnalytics", () => {
       expect(storedAuction).toBeDefined();
       expect(storedAuction?.auctionEnd).toBe(event);
       expect(storedAuction?.missed).toBe(false);
+      expect(storedAuction?.bidWonEvents).toEqual([]);
     });
 
     it("should mark auction as missed when specified", async () => {
@@ -322,10 +324,15 @@ describe("OptablePrebidAnalytics", () => {
 
   describe("trackBidWon", () => {
     beforeEach(() => {
+      jest.useFakeTimers();
       analytics = new OptablePrebidAnalytics(mockOptableInstance, {
         analytics: true,
         tenant: "test-tenant",
       });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     it("should skip if auction data is missing", async () => {
@@ -338,6 +345,7 @@ describe("OptablePrebidAnalytics", () => {
       };
 
       await analytics.trackBidWon(event);
+      await jest.runAllTimersAsync();
 
       expect(mockOptableInstance.witness).not.toHaveBeenCalled();
     });
@@ -372,11 +380,9 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 1.5,
       };
 
-      // First track the auction end
       await analytics.trackAuctionEnd(auctionEndEvent);
-
-      // Then track the bid won
       await analytics.trackBidWon(bidWonEvent);
+      await jest.runAllTimersAsync();
 
       expect(mockOptableInstance.witness).toHaveBeenCalledWith(
         "optable.prebid.auction",
@@ -384,6 +390,7 @@ describe("OptablePrebidAnalytics", () => {
           auctionId: "auction-complete",
           tenant: "test-tenant",
           missed: false,
+          bidWon: [expect.objectContaining({ adUnitCode: "ad-unit-1", bidderCode: "bidder1" })],
         })
       );
     });
@@ -420,12 +427,50 @@ describe("OptablePrebidAnalytics", () => {
 
       await analytics.trackAuctionEnd(auctionEndEvent);
       await analytics.trackBidWon(bidWonEvent, true);
+      await jest.runAllTimersAsync();
 
       expect(mockOptableInstance.witness).toHaveBeenCalledWith(
         "optable.prebid.auction",
         expect.objectContaining({
           missed: true,
         })
+      );
+    });
+
+    it("should accumulate multiple bidWon events and emit one witness with an array", async () => {
+      const auctionId = "auction-multi-unit";
+      const auctionEndEvent = {
+        auctionId,
+        timeout: 3000,
+        bidderRequests: [
+          {
+            bidderCode: "appnexus",
+            bidderRequestId: "req-1",
+            ortb2: {
+              site: { domain: "example.com" },
+              user: { eids: [] },
+            },
+            bids: [],
+          },
+        ],
+        bidsReceived: [],
+        noBids: [],
+        timeoutBids: [],
+      };
+
+      await analytics.trackAuctionEnd(auctionEndEvent);
+      await analytics.trackBidWon({ auctionId, bidderCode: "appnexus", adUnitCode: "div-test-1", cpm: 5.0 });
+      await analytics.trackBidWon({ auctionId, bidderCode: "appnexus", adUnitCode: "div-test-2", cpm: 5.0 });
+      await jest.runAllTimersAsync();
+
+      expect(mockOptableInstance.witness).toHaveBeenCalledTimes(1);
+      const [, properties] = (mockOptableInstance.witness as jest.Mock).mock.calls[0];
+      expect(properties.bidWon).toHaveLength(2);
+      expect(properties.bidWon).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ adUnitCode: "div-test-1" }),
+          expect.objectContaining({ adUnitCode: "div-test-2" }),
+        ])
       );
     });
   });
@@ -743,7 +788,7 @@ describe("OptablePrebidAnalytics", () => {
       expect(storedAuction).toBeDefined();
 
       // The splitTestAssignment should be extracted and merged in toWitness
-      const payload = await analytics.toWitness(storedAuction.auctionEnd, null);
+      const payload = await analytics.toWitness(storedAuction.auctionEnd, []);
       expect(payload.bidderRequests[0].bids[0].splitTestAssignment).toBe("treatment");
     });
 
@@ -793,7 +838,7 @@ describe("OptablePrebidAnalytics", () => {
       const storedAuction = analytics["auctions"].get("auction-no-split-test");
       expect(storedAuction).toBeDefined();
 
-      const payload = await analytics.toWitness(storedAuction.auctionEnd, null);
+      const payload = await analytics.toWitness(storedAuction.auctionEnd, []);
       expect(payload.bidderRequests[0].bids[0].splitTestAssignment).toBeUndefined();
     });
 
@@ -899,7 +944,7 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 1.5,
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, bidWonEvent);
+      const result = await analytics.toWitness(auctionEndEvent, [bidWonEvent]);
 
       expect(result.totalRequests).toBe(2);
       expect(result.bidderRequests).toHaveLength(2);
@@ -937,7 +982,7 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 1.5,
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, bidWonEvent);
+      const result = await analytics.toWitness(auctionEndEvent, [bidWonEvent]);
 
       // Should only include optable EIDs
       expect(result.optableMatchers).toEqual(["matcher1"]);
@@ -976,7 +1021,7 @@ describe("OptablePrebidAnalytics", () => {
         cpm: 1.5,
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, bidWonEvent);
+      const result = await analytics.toWitness(auctionEndEvent, [bidWonEvent]);
 
       expect(window.optable.customAnalytics).toHaveBeenCalled();
       expect(result).toMatchObject(customData);
@@ -1030,6 +1075,8 @@ describe("OptablePrebidAnalytics", () => {
     });
 
     it("should process missed bidWon events", async () => {
+      jest.useFakeTimers();
+
       const witnessspy = jest.fn().mockResolvedValue(undefined);
       const testInstance = {
         witness: witnessspy,
@@ -1081,9 +1128,8 @@ describe("OptablePrebidAnalytics", () => {
       };
 
       analytics["setHooks"](mockPbjs);
-
-      // Wait for async operations to complete
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await jest.runAllTimersAsync();
+      jest.useRealTimers();
 
       expect(witnessspy).toHaveBeenCalledWith(
         "optable.prebid.auction",
@@ -1138,7 +1184,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       // Should only have one source since they have the same source value
       expect(result.optableSources).toEqual(["optable.co"]);
@@ -1170,7 +1216,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       // Should have both sources since they're different
       expect(result.optableSources).toHaveLength(2);
@@ -1205,7 +1251,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       expect(result.optableSources).toEqual(["source1"]);
       expect(result.optableMatchers).toEqual(["matcher1"]);
@@ -1232,7 +1278,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       expect(result.optableSources).toEqual(["source1"]);
       expect(result.optableMatchers).toEqual(["matcher1"]);
@@ -1262,7 +1308,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       expect(result.optableSources).toEqual(["source1"]);
       expect(result.optableMatchers).toEqual(["matcher1"]);
@@ -1298,7 +1344,7 @@ describe("OptablePrebidAnalytics", () => {
         timeoutBids: [],
       };
 
-      const result = await analytics.toWitness(auctionEndEvent, null);
+      const result = await analytics.toWitness(auctionEndEvent, []);
 
       // Should only have one optable source and matcher due to deduplication
       expect(result.optableSources).toEqual(["optable.co"]);
@@ -1338,7 +1384,7 @@ describe("OptablePrebidAnalytics", () => {
       const storedAuction = analytics["auctions"].get("auction-track-dedup");
       expect(storedAuction).toBeDefined();
 
-      const payload = await analytics.toWitness(storedAuction.auctionEnd, null);
+      const payload = await analytics.toWitness(storedAuction.auctionEnd, []);
       // Should only have one source after deduplication
       expect(payload.optableSources).toEqual(["optable.co"]);
       // The last matcher should win

--- a/lib/addons/prebid/analytics.test.ts
+++ b/lib/addons/prebid/analytics.test.ts
@@ -433,6 +433,7 @@ describe("OptablePrebidAnalytics", () => {
         "optable.prebid.auction",
         expect.objectContaining({
           missed: true,
+          optableLoaded: false,
         })
       );
     });
@@ -472,6 +473,62 @@ describe("OptablePrebidAnalytics", () => {
           expect.objectContaining({ adUnitCode: "div-test-2" }),
         ])
       );
+    });
+
+    it("should emit bidWon:[] and bidWonAt:null when no bidWon events arrive", async () => {
+      const auctionEndEvent = {
+        auctionId: "auction-no-bidwon",
+        timeout: 3000,
+        bidderRequests: [
+          {
+            bidderCode: "bidder1",
+            bidderRequestId: "req-1",
+            ortb2: {
+              site: { domain: "example.com" },
+              user: { eids: [] },
+            },
+            bids: [],
+          },
+        ],
+        bidsReceived: [],
+        noBids: [],
+        timeoutBids: [],
+      };
+
+      await analytics.trackAuctionEnd(auctionEndEvent);
+      await jest.runAllTimersAsync();
+
+      expect(mockOptableInstance.witness).toHaveBeenCalledWith(
+        "optable.prebid.auction",
+        expect.objectContaining({ bidWon: [], bidWonAt: null })
+      );
+    });
+
+    it("should delete the auction from the map after the timeout fires", async () => {
+      const auctionId = "auction-cleanup";
+      const auctionEndEvent = {
+        auctionId,
+        timeout: 3000,
+        bidderRequests: [
+          {
+            bidderCode: "bidder1",
+            bidderRequestId: "req-1",
+            ortb2: {
+              site: { domain: "example.com" },
+              user: { eids: [] },
+            },
+            bids: [],
+          },
+        ],
+        bidsReceived: [],
+        noBids: [],
+        timeoutBids: [],
+      };
+
+      await analytics.trackAuctionEnd(auctionEndEvent);
+      expect(analytics["auctions"].has(auctionId)).toBe(true);
+      await jest.runAllTimersAsync();
+      expect(analytics["auctions"].has(auctionId)).toBe(false);
     });
   });
 

--- a/lib/addons/prebid/analytics.ts
+++ b/lib/addons/prebid/analytics.ts
@@ -38,6 +38,7 @@ interface AuctionItem {
   auctionEndTimeoutId: NodeJS.Timeout | null;
   missed: boolean;
   createdAt: Date;
+  bidWonEvents: any[];
 }
 
 class OptablePrebidAnalytics {
@@ -355,16 +356,19 @@ class OptablePrebidAnalytics {
 
     const createdAt = new Date();
     const auctionEndTimeoutId = setTimeout(async () => {
-      const payload = await this.toWitness(event, null, missed);
+      const auction = this.auctions.get(auctionId);
+      if (!auction) return;
+      const effectiveMissed = auction.missed;
+      const payload = await this.toWitness(event, auction.bidWonEvents, effectiveMissed);
       payload["auctionEndAt"] = createdAt.toISOString();
-      payload["bidWonAt"] = null;
-      payload["optableLoaded"] = !missed;
-
+      payload["bidWonAt"] = auction.bidWonEvents.length > 0 ? new Date().toISOString() : null;
+      payload["optableLoaded"] = !effectiveMissed;
       this.sendToWitnessAPI("optable.prebid.auction", payload);
+      this.auctions.delete(auctionId);
     }, this.config.bidWinTimeout);
 
     // Store the auction data
-    this.auctions.set(auctionId, { auctionEnd: event, createdAt, missed, auctionEndTimeoutId });
+    this.auctions.set(auctionId, { auctionEnd: event, createdAt, missed, auctionEndTimeoutId, bidWonEvents: [] });
 
     // Clean up old auctions
     this.cleanupOldAuctions();
@@ -393,18 +397,10 @@ class OptablePrebidAnalytics {
       return;
     }
 
-    if (auction.auctionEndTimeoutId) {
-      clearTimeout(auction.auctionEndTimeoutId);
+    auction.bidWonEvents.push(event);
+    if (missed) {
+      auction.missed = true;
     }
-
-    const payload = await this.toWitness(auction.auctionEnd, event, missed);
-    payload["auctionEndAt"] = auction.createdAt.toISOString();
-    payload["bidWonAt"] = new Date().toISOString();
-    payload["optableLoaded"] = !missed;
-
-    this.sendToWitnessAPI("optable.prebid.auction", payload);
-
-    this.auctions.delete(event.auctionId);
   }
 
   /**
@@ -438,7 +434,7 @@ class OptablePrebidAnalytics {
    * @param missed - True when the original events were already emitted (replayed).
    * @returns A payload object compatible with the Witness API.
    */
-  async toWitness(auctionEndEvent: any, bidWonEvent: any | null, missed = false): Promise<Record<string, any>> {
+  async toWitness(auctionEndEvent: any, bidWonEvents: any[], missed = false): Promise<Record<string, any>> {
     const { auctionId, bidderRequests = [], bidsReceived = [], noBids = [], timeoutBids = [] } = auctionEndEvent;
 
     const oMatchersSet = new Set();
@@ -519,20 +515,11 @@ class OptablePrebidAnalytics {
       optableTargetingDone: oMatchersSet.size || oSourcesSet.size,
       optableMatchers: Array.from(oMatchersSet),
       optableSources: Array.from(oSourcesSet),
-      bidWon: bidWonEvent
-        ? {
-            message:
-              bidWonEvent.bidderCode +
-              " won the ad server auction for ad unit " +
-              bidWonEvent.adUnitCode +
-              " at " +
-              bidWonEvent.cpm +
-              " CPM",
-            bidderCode: bidWonEvent.bidderCode,
-            adUnitCode: bidWonEvent.adUnitCode,
-            cpm: bidWonEvent.cpm,
-          }
-        : null,
+      bidWon: bidWonEvents.map((e) => ({
+        bidderCode: e.bidderCode,
+        adUnitCode: e.adUnitCode,
+        cpm: e.cpm,
+      })),
       missed,
       url: `${window.location.hostname}${window.location.pathname}`,
       tenant: this.config.tenant!,

--- a/lib/addons/prebid/analytics.ts
+++ b/lib/addons/prebid/analytics.ts
@@ -356,12 +356,15 @@ class OptablePrebidAnalytics {
 
     const createdAt = new Date();
     const auctionEndTimeoutId = setTimeout(async () => {
-      const auction = this.auctions.get(auctionId);
-      if (!auction) return;
-      const effectiveMissed = auction.missed;
-      const payload = await this.toWitness(event, auction.bidWonEvents, effectiveMissed);
+      const storedAuction = this.auctions.get(auctionId);
+      if (!storedAuction) return;
+      const effectiveMissed = storedAuction.missed;
+      const payload = await this.toWitness(event, storedAuction.bidWonEvents, effectiveMissed);
       payload["auctionEndAt"] = createdAt.toISOString();
-      payload["bidWonAt"] = auction.bidWonEvents.length > 0 ? new Date().toISOString() : null;
+      payload["bidWonAt"] =
+        storedAuction.bidWonEvents.length > 0
+          ? new Date(Math.min(...storedAuction.bidWonEvents.map((e: any) => e._receivedAt.getTime()))).toISOString()
+          : null;
       payload["optableLoaded"] = !effectiveMissed;
       this.sendToWitnessAPI("optable.prebid.auction", payload);
       this.auctions.delete(auctionId);
@@ -375,21 +378,14 @@ class OptablePrebidAnalytics {
   }
 
   /**
-   * Handle a Prebid `bidWon` event by finalizing the matching auction, clearing
-   * the pending timeout and sending the combined payload to Witness.
+   * Accumulate a Prebid `bidWon` event into the matching auction's event list
+   * for deferred emission when the auction timeout fires.
    * @param event - The raw Prebid bidWon event object.
    * @param missed - True when the event was previously emitted (missed replay).
    * @returns void
    */
   async trackBidWon(event: any, missed: boolean = false) {
-    const filteredEvent = {
-      auctionId: event.auctionId,
-      bidderCode: event.bidderCode,
-      bidId: event.requestId,
-      tenant: this.config.tenant,
-      missed,
-    };
-    this.log("bidWon filtered event", filteredEvent);
+    this.log("bidWon event", { auctionId: event.auctionId, bidderCode: event.bidderCode, missed });
 
     const auction = this.auctions.get(event.auctionId);
     if (!auction) {
@@ -397,7 +393,7 @@ class OptablePrebidAnalytics {
       return;
     }
 
-    auction.bidWonEvents.push(event);
+    auction.bidWonEvents.push({ ...event, _receivedAt: new Date() });
     if (missed) {
       auction.missed = true;
     }
@@ -427,10 +423,10 @@ class OptablePrebidAnalytics {
   }
 
   /**
-   * Convert internal auction state and optional bidWon event into a Witness payload.
+   * Convert internal auction state and accumulated bidWon events into a Witness payload.
    * This collects matcher/source metadata, bid counts and optional custom analytics.
    * @param auctionEndEvent - The `auctionEnd` event object from Prebid.js.
-   * @param bidWonEvent - Optional `bidWon` event when a winning bid exists.
+   * @param bidWonEvents - Array of `bidWon` events accumulated during the auction window.
    * @param missed - True when the original events were already emitted (replayed).
    * @returns A payload object compatible with the Witness API.
    */


### PR DESCRIPTION
## Summary

Fixes the data-loss bug where only the first `bidWon` event per Prebid auction was captured on multi-ad-unit pages (issue [#69](https://github.com/postindustria-tech/optable-issues/issues/69)).

**Root cause:** `trackBidWon` cleared the pending `bidWinTimeout`, emitted the witness immediately, and deleted the auction from the in-memory map. Every subsequent `bidWon` for the same `auctionId` hit the `"Missing 'auctionEnd' event"` guard and was silently dropped.

**Fix:** `trackBidWon` now only accumulates events; the `bidWinTimeout` timer in `trackAuctionEnd` is the sole emit point. After the timeout fires, all collected `bidWon` events are included in the witness payload as an array.

## Changes

### `lib/addons/prebid/analytics.ts`

- **`AuctionItem` interface** — added `bidWonEvents: any[]` accumulator field.
- **`trackBidWon`** — stripped to `auction.bidWonEvents.push(event)` + `auction.missed = true` propagation when called with `missed=true`. No more timeout clear, no early emit, no map deletion.
- **`trackAuctionEnd` setTimeout callback** — reads `auction.bidWonEvents` and `auction.missed` at fire time (so late-arriving `missed=true` propagation is respected), emits the witness with the full array, then removes the auction from the map.
- **`toWitness`** — second parameter changed from `bidWonEvent: any | null` to `bidWonEvents: any[]`; `properties.bidWon` is now always an array of `{ bidderCode, adUnitCode, cpm }` objects (empty array when no `bidWon` arrived within the timeout window).

### `lib/addons/prebid/analytics.test.ts`

- All `toWitness(…, null)` call sites updated to `toWitness(…, [])`.
- `trackBidWon` describe block uses `jest.useFakeTimers()` / `jest.runAllTimersAsync()` to drive the deferred emit.
- `setHooks` "missed bidWon" test migrated to fake timers.
- **New test:** two `trackBidWon` calls for the same auction produce exactly one witness call with a two-element `bidWon` array.
- Added `bidWonEvents: []` assertion to the `trackAuctionEnd` stored-auction test.

## Wire format change

`properties.bidWon` changes from `{ message, bidderCode, adUnitCode, cpm } | null` to `Array<{ bidderCode, adUnitCode, cpm }>`. The companion backend change (handling the array and assigning `win=true` per entry) should be deployed first, per the coordination note in the issue.

## Test plan

- [x] All 53 existing unit tests pass
- [x] New multi-`bidWon` accumulation test passes
- [ ] Deploy backend change first (tracked in companion issue)
- [ ] Manual end-to-end: two-ad-unit page with Prebid debugging injecting wins for both ad units → one `POST /witness` with `properties.bidWon.length === 2`