### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-pnpm-demos-npm/action.yml
+++ b/.github/actions/setup-pnpm-demos-npm/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: echo "pnpm_version=$(grep 'pnpm' mise.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b
       with:
         version: ${{ steps.get-pnpm-version.outputs.pnpm_version }}
     - name: Get pnpm store directory
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
         key: ${{ runner.os }}-pnpm-store-npm-demo-${{ hashFiles('demos/npm/pnpm-lock.yaml') }}

--- a/.github/actions/setup-pnpm-demos-react/action.yml
+++ b/.github/actions/setup-pnpm-demos-react/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: echo "pnpm_version=$(grep 'pnpm' mise.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b
       with:
         version: ${{ steps.get-pnpm-version.outputs.pnpm_version }}
     - name: Get pnpm store directory
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
         key: ${{ runner.os }}-pnpm-store-react-demo-${{ hashFiles('demos/react/pnpm-lock.yaml') }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: echo "pnpm_version=$(grep 'pnpm' mise.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b
       with:
         version: ${{ steps.get-pnpm-version.outputs.pnpm_version }}
     - name: Get pnpm store directory
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup mise
         uses: ./.github/actions/setup-mise
@@ -62,7 +62,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download web artifacts
         uses: actions/download-artifact@v4
@@ -109,13 +109,13 @@ jobs:
           path: browser/dist
 
       - name: Auth to google cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.workload_identity_provider }}
           service_account: ${{ env.service-account }}
 
       - name: Upload SDK to GCS bucket, upload new version
-        uses: google-github-actions/upload-cloud-storage@v2
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: "browser/dist/sdk.js"
           destination: "optable-web-sdk/${{ matrix.sdk-version }}"
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get sdk artifact
         uses: actions/download-artifact@v4
@@ -157,7 +157,7 @@ jobs:
           name: dist-npm-demo
           path: demos/npm/dist
 
-      - uses: "google-github-actions/auth@v2"
+      - uses: "google-github-actions/auth@v3"
         id: auth
         with:
           token_format: "access_token"
@@ -186,7 +186,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - name: Post to Slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
           token: "${{ secrets.SLACK_MESSENGER_APP_TOKEN }}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
@@ -70,7 +70,7 @@ jobs:
       UID2_BASE_URL: ${{ vars.UID2_BASE_URL }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build vanilla demo
         run: make demo-html
@@ -90,7 +90,7 @@ jobs:
         working-directory: demos/react
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download web artifacts
         uses: actions/download-artifact@v4
@@ -122,7 +122,7 @@ jobs:
         working-directory: demos/npm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm demos npm
         uses: ./.github/actions/setup-pnpm-demos-npm

--- a/.github/workflows/reusable-lint-test.yml
+++ b/.github/workflows/reusable-lint-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions to Node.js 24-compatible versions before the June 2, 2026 deadline

## Changes
- \`actions/checkout\` → \`@v6\`
- \`actions/cache\` → \`@v5\`
- \`pnpm/action-setup\` → new SHA \`b307...\`
- \`google-github-actions/auth\` → \`@v3\`
- \`google-github-actions/upload-cloud-storage\` → \`@v3\`
- \`slackapi/slack-github-action\` → \`@v3.0.1\`

## Reference
ClickUp: SOLUTIONS-4376