### PR TITLE
feat: add initContextual flag for automatic pageview tracking with page context

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ JavaScript SDK for integrating with an [Optable Data Connectivity Node (DCN)](ht
     - [TypeScript Types](#typescript-types)
     - [Caching Targeting Data](#caching-targeting-data)
   - [Witness API](#witness-api)
+    - [Contextual Pageview Tracking](#contextual-pageview-tracking)
 - [Using a script tag](#using-a-script-tag)
   - [Option 1: Automatic Initialization](#option-1-automatic-initialization)
   - [Option 2: Manual Initialization with Commands Queue](#option-2-manual-initialization-with-commands-queue)
@@ -142,6 +143,12 @@ When creating an instance of `OptableSDK`, you can pass an `InitConfig` object t
 
 - **`initTargeting` (boolean, default: `false`)**
   If `true`, the SDK will automatically perform a targeting request during initialization and store the response in cache. This ensures the cache is populated with the most up-to-date targeting data as soon as the SDK is loaded.
+
+- **`pageContext` (`PageContextConfig | boolean`, default: `undefined`)**
+  When set, enables page context extraction for contextual intelligence. Set to `true` to use defaults, or pass a `PageContextConfig` object to customize what is extracted (HTML content, content selector, max lengths). Extracted context is automatically attached to the first `witness()` call that uses `{ includeContext: true }`.
+
+- **`initContextual` (boolean, default: `false`)**
+  If `true`, the SDK will automatically fire a `pageview` witness event with full page context during initialization. This is the recommended way to enable contextual pageview tracking without writing custom code. Implies `pageContext: true` when no `pageContext` is explicitly configured.
 
 - **`consent` (`InitConsent`)**
   Defines the consent settings for data collection and processing.
@@ -348,6 +355,53 @@ type WitnessProperties = {
   [key: string]: string | number | boolean;
 };
 ```
+
+### Contextual Pageview Tracking
+
+The SDK can automatically fire a `pageview` witness event with full page context on initialization. This sends semantic content from the page (title, description, keywords, headings, canonical URL, Open Graph tags, and body text) to the DCN for contextual audience assembly.
+
+#### Option 1: Automatic (recommended)
+
+Set `initContextual: true` in your SDK config. The SDK fires the pageview event once after passport initialization, with no additional code required:
+
+```javascript
+const sdk = new OptableSDK({
+  host: "dcn.customer.com",
+  site: "my-site",
+  initContextual: true,
+});
+```
+
+You can combine this with `pageContext` to customize what content is extracted:
+
+```javascript
+const sdk = new OptableSDK({
+  host: "dcn.customer.com",
+  site: "my-site",
+  initContextual: true,
+  pageContext: {
+    contentSelector: "article",
+    maxContentLength: 3000,
+  },
+});
+```
+
+#### Option 2: Manual
+
+Enable `pageContext` in your config and call `witness()` with `{ includeContext: true }` yourself. Context is attached once per page load (subsequent calls with `includeContext: true` send no context):
+
+```javascript
+const sdk = new OptableSDK({
+  host: "dcn.customer.com",
+  site: "my-site",
+  pageContext: true,
+});
+
+// Fire a pageview with full page context attached
+sdk.witness("pageview", {}, { includeContext: true });
+```
+
+To reset the context (e.g. on SPA navigation), call `sdk.resetContext()` before the next `witness()` call.
 
 ## Using a script tag
 

--- a/README.md
+++ b/README.md
@@ -397,8 +397,9 @@ const sdk = new OptableSDK({
   pageContext: true,
 });
 
-// Fire a pageview with full page context attached
-sdk.witness("pageview", {}, { includeContext: true });
+// Fire a pageview with URL property and full page context attached
+const url = `${window.location.hostname}${window.location.pathname}`;
+sdk.witness("pageview", { url }, { includeContext: true });
 ```
 
 To reset the context (e.g. on SPA navigation), call `sdk.resetContext()` before the next `witness()` call.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -72,6 +72,10 @@ type InitConfig = {
   // When enabled, context is sent with the first witness() call after page load.
   // Set to true for defaults, or provide a PageContextConfig object for customization.
   pageContext?: PageContextConfig | boolean;
+  // Automatically send a pageview witness event with page context on SDK initialization.
+  // When true, a 'pageview' event is fired once after passport init with full page context.
+  // Implies pageContext: true when no pageContext is explicitly configured.
+  initContextual?: boolean;
 };
 
 type ResolvedConfig = {
@@ -89,6 +93,7 @@ type ResolvedConfig = {
   sessionID: string;
   skipEnrichment?: boolean;
   initTargeting?: boolean;
+  initContextual?: boolean;
   abTests?: ABTestConfig[];
   additionalTargetingSignals?: TargetingSignals;
   timeout?: string;
@@ -124,6 +129,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     sessionID: init.sessionID ?? generateSessionID(),
     skipEnrichment: init.skipEnrichment,
     initTargeting: init.initTargeting,
+    initContextual: init.initContextual,
     abTests: init.abTests,
     additionalTargetingSignals: init.additionalTargetingSignals,
     timeout: init.timeout,

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -39,6 +39,9 @@ class OptableSDK {
   constructor(dcn: InitConfig) {
     this.dcn = getConfig(dcn);
     this.contextConfig = normalizeContextConfig(dcn.pageContext);
+    if (this.dcn.initContextual && !this.contextConfig) {
+      this.contextConfig = {};
+    }
     this.init = this.initialize();
   }
 
@@ -49,6 +52,10 @@ class OptableSDK {
 
     if (this.dcn.initTargeting) {
       this.targeting().catch(() => {});
+    }
+
+    if (this.dcn.initContextual) {
+      this.witness("pageview", {}, { includeContext: true }).catch(() => {});
     }
   }
 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -55,7 +55,8 @@ class OptableSDK {
     }
 
     if (this.dcn.initContextual) {
-      this.witness("pageview", {}, { includeContext: true }).catch(() => {});
+      const url = `${window.location.hostname}${window.location.pathname}`;
+      this.witness("pageview", { url }, { includeContext: true }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `initContextual?: boolean` to `InitConfig` — when `true`, the SDK automatically fires a `pageview` witness event with full page context during initialization (after passport init)
- Implies `pageContext: true` when no `pageContext` is explicitly configured, so callers only need one flag
- Follows the same non-blocking fire-and-forget pattern as `initTargeting`
- Documents both the flag and the manual `witness(..., { includeContext: true })` approach in README

## Motivation

Publishers integrating Optable for contextual audience assembly need to send page context on load. Previously this required custom integration code in each SDK bundle (e.g. the Playwire solution bundle). This flag makes it a first-class SDK feature with a single line of config.

## Usage

```javascript
const sdk = new OptableSDK({
  host: "dcn.customer.com",
  site: "my-site",
  initContextual: true,          // fire pageview + context on init
  // pageContext: { contentSelector: "article" }  // optional customization
});
```

## Changes

- `lib/config.ts` — `initContextual` added to `InitConfig`, `ResolvedConfig`, and `getConfig`
- `lib/sdk.ts` — constructor defaults `contextConfig` to `{}` when `initContextual` is set without `pageContext`; `initialize()` fires the witness call
- `README.md` — new `initContextual` and `pageContext` entries in Optional Keys; new "Contextual Pageview Tracking" section under Witness API with automatic and manual usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)