### PR TITLE
feat(analytics): track full optable RTD provider config in auction witness

### DIFF
--- a/lib/addons/prototypes/analytics.js
+++ b/lib/addons/prototypes/analytics.js
@@ -57,6 +57,8 @@ class OptablePrebidAnalytics {
   }
 
   setHooks(pbjs) {
+    this.optableProvider = pbjs?.getConfig?.()?.realTimeData?.dataProviders?.find((p) => p.name === "optable") ?? null;
+
     this.log("Processing missed auctionEnd");
     pbjs.getEvents().forEach((event) => {
       if (event.eventType === "auctionEnd") {
@@ -279,6 +281,7 @@ class OptablePrebidAnalytics {
         tenant: this.config.tenant,
         optableWrapperVersion: SDK_WRAPPER_VERSION, // eslint-disable-line no-undef
         prebidjsVersion: this.prebidInstance?.version || "unknown",
+        optableProvider: this.optableProvider ?? null,
         sessionDepth: sessionStorage?.optableSessionDepth || 1,
         pageAuctionsCount: window.optable?.pageAuctionsCount || 1,
       };


### PR DESCRIPTION
## Summary

- In `setHooks()`, capture the full optable provider object from `pbjs.getConfig().realTimeData.dataProviders` and store as `this.optableProvider`
- Include `optableProvider` in the `auction_processed` witness payload alongside the existing `prebidjsVersion`

This lets us see the complete provider config (including `params.handleRtd` and any other params) per auction, without having to pick individual fields upfront.

## Test plan
- [ ] Verify `optableProvider` appears in witness payloads with correct shape when optable RTD provider is configured
- [ ] Verify `optableProvider: null` when no optable provider is found in pbjs config