### PR TITLE
fix(rtd): strip _ref from EIDs before merging into prebid

### DIFF
--- a/lib/core/prebid/rtd.ts
+++ b/lib/core/prebid/rtd.ts
@@ -321,7 +321,8 @@ function handleRtd(
 
     routes.forEach((route) => {
       eidsPerRoute[route] = eidsPerRoute[route] ?? { user: { ext: { eids: [] } } };
-      eidsPerRoute[route].user!.ext!.eids!.push(eid);
+      const { _ref, ...clean } = eid as any;
+      eidsPerRoute[route].user!.ext!.eids!.push(clean);
       config.log("info", `EID with source ${eid.source} routed to ${route}`);
     });
     processedEids += 1;


### PR DESCRIPTION
## Summary
- Strip the internal `_ref` property from EIDs before pushing them into prebid's `ortb2Fragments`
- `_ref` contains UID2 refresh metadata (refresh tokens, expiry timestamps) used by the SDK wrapper's cache layer — it should never leak into the bid stream

## Test plan
- [ ] Verify `_ref` no longer appears in `reqBidsConfigObj.ortb2Fragments.global.user.ext.eids` after RTD merge
- [ ] Verify UID2 refresh still works (reads `_ref` from localStorage cache, not from prebid fragments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)