### PR TITLE
(For Analytics Prototype instead of v2) Change key names for sessionDepth and pageAuctionsCount in Analytics …

### DIFF
--- a/lib/addons/prototypes/analytics.js
+++ b/lib/addons/prototypes/analytics.js
@@ -23,7 +23,7 @@ class OptablePrebidAnalytics {
     this.auctions = {};
     this.maxAuctionDataSize = 20;
 
-    sessionStorage.optableSessionDepth = (Number(sessionStorage?.optableSessionDepth) || 0) + 1;
+    sessionStorage.optableSessionDepthIndex = (Number(sessionStorage?.optableSessionDepthIndex) || 0) + 1;
 
     this.log("OptablePrebidAnalytics initialized");
   }
@@ -103,7 +103,7 @@ class OptablePrebidAnalytics {
   async trackAuctionEnd(event, missed) {
     const { auctionId, timeout, bidderRequests = [], bidsReceived = [], noBids = [], timeoutBids = [] } = event;
 
-    window.optable.pageAuctionsCount = (Number(window.optable.pageAuctionsCount) || 0) + 1;
+    window.optable.pageAuctionIndex = (Number(window.optable.pageAuctionIndex) || 0) + 1;
 
     this.log(`Processing auction ${auctionId} with ${bidderRequests.length} bidder requests`);
 
@@ -279,8 +279,8 @@ class OptablePrebidAnalytics {
         tenant: this.config.tenant,
         optableWrapperVersion: SDK_WRAPPER_VERSION, // eslint-disable-line no-undef
         prebidjsVersion: this.prebidInstance?.version || "unknown",
-        sessionDepth: sessionStorage?.optableSessionDepth || 1,
-        pageAuctionsCount: window.optable?.pageAuctionsCount || 1,
+        sessionDepth: sessionStorage?.optableSessionDepthIndex || 1,
+        pageAuctionsCount: window.optable?.pageAuctionIndex || 1,
       };
       // Log summary with bid counts
       this.log(


### PR DESCRIPTION
…prototype

In a nutshell, both the prototype and prod version of analytics are incrementing these values:
- pageAuctionsCount
- sessionDepth

Which means that the values are reported in double.

Example:
- User goes to the page
  - sessionStorage.optableSessionDepth is incremented by prototype analytics
  - sessionStorage.optableSessionDepth is incremented by prod analytics
  - sessionDepth is now at 2, but the user only visited one page in this session
- Then auction start, both analytics record sessionDepth as 2 instead of one.
Same thing happens for pageAuctionsCount, which will return 1 for the first analytics loaded and then 2 for the second analytics loaded. One of them is not correct, but we cannot find which one is wrong.

This PR changes the sessionStorage key and javascript variable names to avoid this conflict.

I decided to edit the prototype one so that we can keep the prod/V2 one with the same key/variable name as the names in the analytics, avoid confusion in the future.