### PR TITLE
fix(analytics/ prototype): detect in-flight auctions as missed, remove bidWon

### DIFF
--- a/lib/addons/prototypes/analytics.js
+++ b/lib/addons/prototypes/analytics.js
@@ -21,6 +21,7 @@ class OptablePrebidAnalytics {
 
     // Store auction data
     this.auctions = {};
+    this.missedAuctionIds = new Set();
     this.maxAuctionDataSize = 20;
 
     sessionStorage.optableSessionDepth = (Number(sessionStorage?.optableSessionDepth) || 0) + 1;
@@ -57,26 +58,25 @@ class OptablePrebidAnalytics {
   }
 
   setHooks(pbjs) {
-    this.log("Processing missed auctionEnd");
+    this.log("Processing past events");
     pbjs.getEvents().forEach((event) => {
-      if (event.eventType === "auctionEnd") {
-        this.log("auction missed");
+      if (event.eventType === "auctionInit") {
+        this.missedAuctionIds.add(event.args.auctionId);
+      } else if (event.eventType === "auctionEnd") {
+        this.missedAuctionIds.delete(event.args.auctionId);
+        this.log(`auction ${event.args.auctionId} missed (completed before hook)`);
         this.trackAuctionEnd(event.args, true);
-      }
-      if (event.eventType === "bidWon") {
-        this.log("bid won missed");
-        this.trackBidWon(event.args, true);
       }
     });
 
     this.log("Hooking into Prebid.js events");
     pbjs.onEvent("auctionEnd", (event) => {
-      this.log("auctionEnd event received");
-      this.trackAuctionEnd(event);
-    });
-    pbjs.onEvent("bidWon", (event) => {
-      this.log("bidWon event received");
-      this.trackBidWon(event);
+      const missed = this.missedAuctionIds.has(event.auctionId);
+      if (missed) {
+        this.missedAuctionIds.delete(event.auctionId);
+      }
+      this.log(`auctionEnd event received, missed=${missed}`);
+      this.trackAuctionEnd(event, missed);
     });
   }
 
@@ -301,18 +301,6 @@ class OptablePrebidAnalytics {
     }
   }
 
-  trackBidWon(event, missed) {
-    const filteredEvent = {
-      auctionId: event.auctionId,
-      bidderCode: event.bidderCode,
-      bidId: event.requestId,
-      tenant: this.config.tenant,
-      missed,
-    };
-    this.log("bidWon filtered event", filteredEvent);
-    this.sendToWitnessAPI("bid_won", filteredEvent);
-  }
-
   /**
    * Clean up old auctions to prevent memory leaks
    */
@@ -330,6 +318,7 @@ class OptablePrebidAnalytics {
    */
   clearData() {
     this.auctions = {};
+    this.missedAuctionIds.clear();
     this.log("All analytics data cleared");
   }
 }


### PR DESCRIPTION
## Summary

- **Fix missed auction detection**: auctions that fired `auctionInit` before our analytics hook was set, but whose `auctionEnd` arrives after, are now correctly marked as `missed=true`. Previously only fully-completed past auctions (both `auctionInit` and `auctionEnd` in `getEvents()`) were caught.
- **Remove `bidWon` tracking**: the `trackBidWon` method and all `bidWon` event listeners (replay + live) are removed — no longer needed.

## How it works

1. On init, replay past events in a single pass: collect `auctionInit` IDs into `missedAuctionIds`, then when an `auctionEnd` is encountered, remove from set and process as missed.
2. Any IDs remaining in `missedAuctionIds` after replay are auctions that started but haven't ended yet (in-flight).
3. Live `auctionEnd` listener checks `missedAuctionIds` — if the auction ID is present, it's an in-flight auction we missed, so it's marked `missed=true` and removed from the set.

## Test plan

- [ ] Deploy to a test page where the SDK loads after Prebid has already started auctions
- [ ] Verify in-flight auctions (auctionInit fired, auctionEnd not yet fired at hook time) are marked `missed=true` in witness payload
- [ ] Verify auctions that start after hook is set are marked `missed=false`
- [ ] Verify no `bid_won` witness events are emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)