### PR TITLE
rtd: fall back to global routing for unknown bidders

### DIFF
--- a/lib/core/prebid/rtd.ts
+++ b/lib/core/prebid/rtd.ts
@@ -346,12 +346,13 @@ function handleRtd(
     if (route === "global") {
       globalEidsCount += count;
       skippedEids += merge(config, reqBidsConfigObj.ortb2Fragments.global, ortb2);
-    } else {
+    } else if (route in reqBidsConfigObj.ortb2Fragments.bidder) {
       bidderEidsCount += count;
-      const bidder = reqBidsConfigObj.ortb2Fragments.bidder[route] ?? {};
-      skippedEids += merge(config, bidder, ortb2);
-      // eslint-disable-next-line no-param-reassign
-      reqBidsConfigObj.ortb2Fragments.bidder[route] = bidder;
+      skippedEids += merge(config, reqBidsConfigObj.ortb2Fragments.bidder[route], ortb2);
+    } else {
+      config.log("info", `Bidder "${route}" not in auction, routing ${count} EID(s) to global`);
+      globalEidsCount += count;
+      skippedEids += merge(config, reqBidsConfigObj.ortb2Fragments.global, ortb2);
     }
   });
 


### PR DESCRIPTION
## Summary

- When a bidder route from `defaultEIDSources` doesn't exist in the current auction, route EIDs globally instead of creating phantom bidder entries

## Problem

`defaultEIDSources` maps EID sources to specific bidders (e.g. `smartadserver.com` → `smartadserver`). When those bidders don't exist in the publisher's Prebid config, the RTD module creates new entries in `ortb2Fragments.bidder` for non-existent bidders. Prebid.js then generates `eidpermissions` with `"bidders": []`, and PBS rejects the request:

```
Invalid request: request.ext.prebid.data.eidpermissions[0]
missing or empty required field: "bidders"
```

Affected customers: Unwind, Arena, MediaCo, MyCode, DDM — any publisher using ID5 enrichment where the enriched EID sources (smartadserver, gumgum, triplelift, etc.) don't match their PBS bidder config.

## Fix

One-line change in the merge phase of `handleRtd()`: check `route in reqBidsConfigObj.ortb2Fragments.bidder` before merging per-bidder. Unknown bidders fall back to global routing.

**Before**: blindly creates `ortb2Fragments.bidder[route]` → phantom bidder → empty eidpermissions → PBS error

**After**: only merges to existing bidders; unknown routes merge to `ortb2Fragments.global` → EIDs available to all bidders, no phantom entries

## Test plan

- [ ] Build succeeds
- [ ] Existing tests pass
- [ ] With `defaultEIDSources` and a publisher missing smartadserver bidder: no `eidpermissions` with empty bidders in PBS payload
- [ ] EIDs for unknown bidders appear in global `user.ext.eids` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)