### PR TITLE
Fix originSlug for prototype analytics

### DIFF
--- a/lib/addons/prototypes/analytics.js
+++ b/lib/addons/prototypes/analytics.js
@@ -281,7 +281,7 @@ class OptablePrebidAnalytics {
         prebidjsVersion: this.prebidInstance?.version || "unknown",
         sessionDepth: sessionStorage?.optableSessionDepthIndex || 1,
         pageAuctionsCount: window.optable?.pageAuctionIndex || 1,
-        originSlug: this.optableInstance?.dcn?.site || window.optable?.site || "unknown",
+        originSlug: window.optable?.site || this.optableInstance?.dcn?.site || "unknown", // optable.site first since dcn is analytics always
       };
       // Log summary with bid counts
       this.log(


### PR DESCRIPTION
prototype version only as dcn.site is always analytics