### PR TITLE
Add web-sdk PR description template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Why
+
+<!-- What problem does this solve? Link Slack/Sentry/issue if relevant -->
+
+## What Changed
+
+<!-- Bullet points: [component]: change + reason if non-obvious -->
+
+## How to Test
+
+<!-- How to QA/Test this PR -->
+
+- [ ] Tested
+- [ ] Docs / README updated (if public API changed)
+
+<!-- Screenshot or recording from demos/ if behavior is visible -->
+
+## Notes
+
+<!-- Tradeoffs, edge cases, migration steps, follow-ups -->
+
+- [ ] Breaking change
+- [ ] Requires release <!-- check if a version bump should be published after merge -->


### PR DESCRIPTION
## Why
No template for web-sdk PRs. This makes it easier to give context on the changes.
## What Changed
Adding the template

## How to Test
No need for testing

- [x] Tested
- [x] Docs / README updated (if public API changed)

<!-- Screenshot or recording from demos/ if behavior is visible -->

## Notes

<!-- Tradeoffs, edge cases, migration steps, follow-ups -->

- [ ] Breaking change
- [ ] Requires release <!-- check if a version bump should be published after merge -->