### PR TITLE
Get splitTestAssignment from SDK bundle, if provided

### DIFF
--- a/lib/addons/prebid/analytics.test.ts
+++ b/lib/addons/prebid/analytics.test.ts
@@ -322,6 +322,76 @@ describe("OptablePrebidAnalytics", () => {
     });
   });
 
+  describe("trackAuctionEnd - split test assignment", () => {
+    function makeEvent(bids: any[]) {
+      return {
+        auctionId: "auction-split-test",
+        timeout: 3000,
+        bidderRequests: [
+          {
+            bidderCode: "bidder1",
+            bidderRequestId: "req-1",
+            ortb2: { site: { domain: "example.com" }, user: { eids: [] } },
+            bids,
+          },
+        ],
+        bidsReceived: [],
+        noBids: [],
+        timeoutBids: [],
+      };
+    }
+
+    it("does nothing when getSplitTestAssignment is not configured", async () => {
+      analytics = new OptablePrebidAnalytics(mockOptableInstance);
+      const bid = { bidId: "bid-1" };
+      await analytics.trackAuctionEnd(makeEvent([bid]));
+
+      expect(bid).not.toHaveProperty("ortb2Imp");
+    });
+
+    it("does nothing when getSplitTestAssignment returns undefined", async () => {
+      analytics = new OptablePrebidAnalytics(mockOptableInstance, {
+        getSplitTestAssignment: () => undefined,
+      });
+      const bid = { bidId: "bid-1" };
+      await analytics.trackAuctionEnd(makeEvent([bid]));
+
+      expect(bid).not.toHaveProperty("ortb2Imp");
+    });
+
+    it("tags every bid's ortb2Imp.ext.optable.splitTestAssignment", async () => {
+      analytics = new OptablePrebidAnalytics(mockOptableInstance, {
+        getSplitTestAssignment: () => "all",
+      });
+      const bidA: any = { bidId: "bid-1" };
+      const bidB: any = { bidId: "bid-2" };
+      await analytics.trackAuctionEnd(makeEvent([bidA, bidB]));
+
+      expect(bidA.ortb2Imp.ext.optable.splitTestAssignment).toBe("all");
+      expect(bidB.ortb2Imp.ext.optable.splitTestAssignment).toBe("all");
+    });
+
+    it("does not override an already-set splitTestAssignment", async () => {
+      analytics = new OptablePrebidAnalytics(mockOptableInstance, {
+        getSplitTestAssignment: () => "all",
+      });
+      const bid: any = { bidId: "bid-1", ortb2Imp: { ext: { optable: { splitTestAssignment: "control" } } } };
+      await analytics.trackAuctionEnd(makeEvent([bid]));
+
+      expect(bid.ortb2Imp.ext.optable.splitTestAssignment).toBe("control");
+    });
+
+    it("preserves other fields already present on ortb2Imp.ext.optable", async () => {
+      analytics = new OptablePrebidAnalytics(mockOptableInstance, {
+        getSplitTestAssignment: () => "all",
+      });
+      const bid: any = { bidId: "bid-1", ortb2Imp: { ext: { optable: { foo: "bar" } } } };
+      await analytics.trackAuctionEnd(makeEvent([bid]));
+
+      expect(bid.ortb2Imp.ext.optable).toEqual({ foo: "bar", splitTestAssignment: "all" });
+    });
+  });
+
   describe("trackBidWon", () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/lib/addons/prebid/analytics.ts
+++ b/lib/addons/prebid/analytics.ts
@@ -31,6 +31,7 @@ interface OptablePrebidAnalyticsConfig {
   samplingSeed?: string;
   samplingRate?: number;
   samplingRateFn?: () => boolean;
+  getSplitTestAssignment?: () => string | undefined;
 }
 
 interface AuctionItem {
@@ -226,6 +227,19 @@ class OptablePrebidAnalytics {
     const { auctionId, timeout, bidderRequests = [], bidsReceived = [], noBids = [], timeoutBids = [] } = event;
 
     this.log(`Processing auction ${auctionId} with ${bidderRequests.length} bidder requests`);
+
+    const splitTestAssignment = this.config.getSplitTestAssignment?.();
+    if (splitTestAssignment) {
+      bidderRequests.forEach((br: any) => {
+        (br.bids || []).forEach((b: any) => {
+          if (b.ortb2Imp?.ext?.optable?.splitTestAssignment) return;
+          b.ortb2Imp = b.ortb2Imp || {};
+          b.ortb2Imp.ext = b.ortb2Imp.ext || {};
+          b.ortb2Imp.ext.optable = b.ortb2Imp.ext.optable || {};
+          b.ortb2Imp.ext.optable.splitTestAssignment = splitTestAssignment;
+        });
+      });
+    }
 
     (window as any).optable = (window as any).optable || {};
     (window as any).optable.pageAuctionsCount = (Number((window as any).optable.pageAuctionsCount) || 0) + 1;

--- a/lib/addons/prototypes/analytics.js
+++ b/lib/addons/prototypes/analytics.js
@@ -107,6 +107,19 @@ class OptablePrebidAnalytics {
 
     this.log(`Processing auction ${auctionId} with ${bidderRequests.length} bidder requests`);
 
+    const splitTestAssignment = this.config.getSplitTestAssignment?.();
+    if (splitTestAssignment) {
+      bidderRequests.forEach((br) => {
+        (br.bids || []).forEach((b) => {
+          if (b.ortb2Imp?.ext?.optable?.splitTestAssignment) return;
+          b.ortb2Imp = b.ortb2Imp || {};
+          b.ortb2Imp.ext = b.ortb2Imp.ext || {};
+          b.ortb2Imp.ext.optable = b.ortb2Imp.ext.optable || {};
+          b.ortb2Imp.ext.optable.splitTestAssignment = splitTestAssignment;
+        });
+      });
+    }
+
     // Build auction object with bidder requests and EID flags
     const auction = {
       auctionId,


### PR DESCRIPTION
and doesn't override if splitTestAssignment is already set (in case it is set server-side)

## Why

Split-test assignment tagging (`ortb2Imp.ext.optable.splitTestAssignment`) is currently copy-pasted as a `trackAuctionEnd` monkey-patch across at least 4 SDK bundles (ezoic, britannica, publift, aditude — the latter merged just this week, #612). Each bundle wraps `analytics(_v2).trackAuctionEnd` identically to inject the same field before analytics processes the auction. Centralizing this in the SDK removes the duplication and the drift risk of bundles copy-pasting it slightly differently.

## What Changed

- `addons/prebid/analytics.ts` (v2) / `addons/prototypes/analytics.js` (v1): added optional `getSplitTestAssignment?: () => string | undefined` config callback.
- `trackAuctionEnd`: when configured, tags every bid's `ortb2Imp.ext.optable.splitTestAssignment` with the callback's return value — **skipped if the bid already has a `splitTestAssignment` set** (e.g. set server-side upstream), so this never clobbers an existing value.
- No-op (existing behavior unchanged) when `getSplitTestAssignment` is omitted.
- Mapping/semantics of the assignment value (e.g. a bundle's `'none'` → `'test'` relabeling) intentionally stay owned by the calling bundle, not baked into the SDK — the callback returns the final string to tag.

## How to Test

- `npx jest lib/addons/prebid/analytics.test.ts` — 5 new cases under `trackAuctionEnd - split test assignment` (no-op when unconfigured, tags all bids, does not override existing assignment, preserves other `ext.optable` fields). Full suite: 452/452 passing.
- [x] Tested
- [ ] Docs / README updated (if public API changed)

<!-- Screenshot or recording from demos/ if behavior is visible -->

## Notes

- Not breaking — new optional config field, fully backward compatible when omitted.
- Follow-up (separate PRs, per bundle, after this ships): migrate ezoic, britannica, publift, aditude off their local `trackAuctionEnd` monkey-patch onto this config option.
- [ ] Breaking change
- [x] Requires release - new SDK version needed before bundles can consume this