### PR TITLE
fix(prebid-analytics): send optableTargetingDone as '1'/'0' string, not a count

### DIFF
--- a/lib/addons/prebid/analytics.test.ts
+++ b/lib/addons/prebid/analytics.test.ts
@@ -258,6 +258,115 @@ describe("OptablePrebidAnalytics", () => {
       expect(result.optableMatchers).toEqual([]);
       expect(result.optableSources).toEqual([]);
     });
+
+    it("optableTargetingDone: '1' when a single Optable matcher is present", async () => {
+      const result = await analytics.toWitness(
+        {
+          auctionId: "auction-targeting-one-matcher",
+          bidderRequests: [
+            {
+              bidderCode: "bidder1",
+              bidderRequestId: "req-1",
+              ortb2: {
+                site: { domain: "example.com" },
+                user: { eids: [{ inserter: "optable.co", matcher: "uid2", source: "uid2.com" }] },
+              },
+              bids: [],
+            },
+          ],
+          bidsReceived: [],
+          noBids: [],
+          timeoutBids: [],
+        },
+        []
+      );
+
+      expect(result.optableTargetingDone).toBe("1");
+    });
+
+    it("optableTargetingDone: '1' when two Optable matchers are present (uid2 + id5)", async () => {
+      // Regression: previously sent `oMatchersSet.size` (the number 2) which Spark
+      // coerced to "2" — matching neither IN ('1','true') nor IN ('0','false') →
+      // processor classified every such auction as status='unknown' instead of 'enriched'.
+      const result = await analytics.toWitness(
+        {
+          auctionId: "auction-targeting-two-matchers",
+          bidderRequests: [
+            {
+              bidderCode: "bidder1",
+              bidderRequestId: "req-1",
+              ortb2: {
+                site: { domain: "example.com" },
+                user: {
+                  eids: [
+                    { inserter: "optable.co", matcher: "uid2", source: "uid2.com" },
+                    { inserter: "optable.co", matcher: "id5", source: "id5-sync.com" },
+                  ],
+                },
+              },
+              bids: [],
+            },
+          ],
+          bidsReceived: [],
+          noBids: [],
+          timeoutBids: [],
+        },
+        []
+      );
+
+      expect(result.optableTargetingDone).toBe("1");
+      expect(result.optableMatchers).toEqual(["uid2", "id5"]);
+    });
+
+    it("optableTargetingDone: '0' when no Optable EIDs are present", async () => {
+      const result = await analytics.toWitness(
+        {
+          auctionId: "auction-targeting-no-eids",
+          bidderRequests: [
+            {
+              bidderCode: "bidder1",
+              bidderRequestId: "req-1",
+              ortb2: {
+                site: { domain: "example.com" },
+                user: { eids: [] },
+              },
+              bids: [],
+            },
+          ],
+          bidsReceived: [],
+          noBids: [],
+          timeoutBids: [],
+        },
+        []
+      );
+
+      expect(result.optableTargetingDone).toBe("0");
+    });
+
+    it("optableTargetingDone: '1' when Optable sources are present but no named matcher", async () => {
+      const result = await analytics.toWitness(
+        {
+          auctionId: "auction-targeting-source-only",
+          bidderRequests: [
+            {
+              bidderCode: "bidder1",
+              bidderRequestId: "req-1",
+              ortb2: {
+                site: { domain: "example.com" },
+                user: { eids: [{ inserter: "optable.co", source: "liveramp.com" }] },
+              },
+              bids: [],
+            },
+          ],
+          bidsReceived: [],
+          noBids: [],
+          timeoutBids: [],
+        },
+        []
+      );
+
+      expect(result.optableTargetingDone).toBe("1");
+    });
   });
 
   describe("trackAuctionEnd", () => {

--- a/lib/addons/prebid/analytics.ts
+++ b/lib/addons/prebid/analytics.ts
@@ -600,7 +600,7 @@ class OptablePrebidAnalytics {
       // Processor schema declares optableTargetingDone as STRING and checks IN ('1','true').
       // Send '1'/'0' so Spark reads a predictable string regardless of matcher count.
       // A raw count (e.g. 2) coerces to "2" which matches neither branch → status='unknown'.
-      optableTargetingDone: oMatchersSet.size > 0 || oSourcesSet.size > 0 ? '1' : '0',
+      optableTargetingDone: oMatchersSet.size > 0 || oSourcesSet.size > 0 ? "1" : "0",
       optableMatchers: Array.from(oMatchersSet),
       optableSources: Array.from(oSourcesSet),
       bidWon: bidWonEvents.map((e) => ({

--- a/lib/addons/prebid/analytics.ts
+++ b/lib/addons/prebid/analytics.ts
@@ -597,7 +597,10 @@ class OptablePrebidAnalytics {
       adUnitCode,
       totalRequests: bidderRequests.length,
       optableSampling: this.config.samplingRate || 1,
-      optableTargetingDone: oMatchersSet.size || oSourcesSet.size,
+      // Processor schema declares optableTargetingDone as STRING and checks IN ('1','true').
+      // Send '1'/'0' so Spark reads a predictable string regardless of matcher count.
+      // A raw count (e.g. 2) coerces to "2" which matches neither branch → status='unknown'.
+      optableTargetingDone: oMatchersSet.size > 0 || oSourcesSet.size > 0 ? '1' : '0',
       optableMatchers: Array.from(oMatchersSet),
       optableSources: Array.from(oSourcesSet),
       bidWon: bidWonEvents.map((e) => ({


### PR DESCRIPTION
## Summary

- `optableTargetingDone` was set to `oMatchersSet.size || oSourcesSet.size` — a JS number (0, 1, 2, …)
- The analytics processor schema declares this field as `STRING` and classifies status via `IN ('1', 'true')` / `IN ('0', 'false')`
- Spark's JSON reader coerces a JSON number to its string form, so `2` (uid2 + id5 active) arrived as `"2"` — matching neither branch → `status = 'unknown'` for every enriched auction with 2+ matchers
- Single-matcher case worked by coincidence: `"1" ∈ ('1', 'true')`

## Fix

Send the literal string `'1'` (enriched) or `'0'` (not enriched). The full matcher/source identity is already carried by `optableMatchers` and `optableSources` arrays, which the processor stores directly in `fact_impression_opportunity.matchers`.

## Impact

Any tenant running both uid2 and id5 (the typical Optable configuration) was having every enriched auction silently classified as `'unknown'` instead of `'enriched'` in the Prebid analytics fact tables.

## Test plan

- [ ] Verify `optableTargetingDone` in witness payload is `'1'` when Optable EIDs are present (any number of matchers)
- [ ] Verify `optableTargetingDone` is `'0'` when no Optable EIDs are present
- [ ] Confirm `optableMatchers` array still carries the full list of active matchers

🤖 Generated with [Claude Code](https://claude.com/claude-code)