### PR TITLE
feat(config): add insecure flag to allow HTTP traffic for testing

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -69,6 +69,8 @@ type InitConfig = {
   // When provided, the server will attempt to answer within the given time limit.
   // Some APIs like targeting may return partial responses depending at which stage the timeout occurred.
   timeout?: string;
+  // Allow insecure HTTP traffic. For testing purposes only — do not use in production.
+  insecure?: boolean;
   // Page context configuration for extracting semantic content from the page.
   // When enabled, context is sent with the first witness() call after page load.
   // Set to true for defaults, or provide a PageContextConfig object for customization.
@@ -105,6 +107,7 @@ type ResolvedConfig = {
   abTests?: ABTestConfig[];
   additionalTargetingSignals?: TargetingSignals;
   timeout?: string;
+  insecure?: boolean;
 };
 
 const DCN_DEFAULTS = {
@@ -141,6 +144,7 @@ function getConfig(init: InitConfig): ResolvedConfig {
     abTests: init.abTests,
     additionalTargetingSignals: init.additionalTargetingSignals,
     timeout: init.timeout,
+    insecure: init.insecure,
   };
 
   if (init.consent?.static) {

--- a/lib/core/network.test.js
+++ b/lib/core/network.test.js
@@ -33,6 +33,21 @@ describe("buildRequest", () => {
     ]);
   });
 
+  it("uses http when insecure is true", () => {
+    const dcn = {
+      cookies: true,
+      host: "host",
+      site: "site",
+      consent: {},
+      sessionID: "123",
+      insecure: true,
+    };
+
+    const request = buildRequest("/path", dcn, { method: "GET" });
+    const url = new URL(request.url);
+    expect(url.protocol).toBe("http:");
+  });
+
   it("omits credentials when device access isnt granted", () => {
     const dcn = {
       cookies: true,

--- a/lib/core/network.ts
+++ b/lib/core/network.ts
@@ -3,9 +3,9 @@ import { default as buildInfo } from "../build.json";
 import { LocalStorage } from "./storage";
 
 function buildRequest(path: string, config: ResolvedConfig, init?: RequestInit): Request {
-  const { host, cookies } = config;
+  const { host, cookies, insecure } = config;
 
-  const url = new URL(path, `https://${host}`);
+  const url = new URL(path, `${insecure ? "http" : "https"}://${host}`);
   url.searchParams.set("osdk", `web-${buildInfo.version}`);
   url.searchParams.set("sid", config.sessionID);
 


### PR DESCRIPTION
Adds an optional `insecure` boolean to InitConfig/ResolvedConfig that switches the SDK from https:// to http:// when set.  This allows local in-browser testing.