### PR TITLE
abTestAssignment: defer setupAB hooks onto pbjs.que when Prebid not ready

### DIFF
--- a/lib/addons/abTestAssignment.ts
+++ b/lib/addons/abTestAssignment.ts
@@ -134,13 +134,28 @@ export function setupAB(config: SetupABConfig): ABTestSetupResult {
     });
   }
 
-  function setHooks(pbjsInstance: any): void {
+  function registerHooks(pbjsInstance: any): void {
     pbjsInstance.getEvents().forEach((event: any) => {
       if (event.eventType === "auctionEnd") {
         applyToAuctionEvent(event.args);
       }
     });
     pbjsInstance.onEvent("auctionEnd", applyToAuctionEvent);
+  }
+
+  // Mirrors OptablePrebidAnalytics.hookIntoPrebid: when Prebid.js has not
+  // finished loading yet (`onEvent` is not a function), defer registration onto
+  // its command queue so hooks attach once the real global drains `que`.
+  // This lets callers pass a queue-only stub (`{ que: [] }`) safely instead of
+  // having to queue `setHooks` themselves.
+  function setHooks(pbjsInstance: any): void {
+    if (!pbjsInstance) return;
+    if (typeof pbjsInstance.onEvent !== "function") {
+      pbjsInstance.que = pbjsInstance.que || [];
+      pbjsInstance.que.push(() => registerHooks(pbjsInstance));
+    } else {
+      registerHooks(pbjsInstance);
+    }
   }
 
   if (pbjs) {


### PR DESCRIPTION
## Why

`setupAB` stamps `ortb2Imp.ext.optable.splitTestAssignment` onto bids by hooking Prebid's `auctionEnd`. Its `setHooks` calls `pbjs.getEvents()` / `pbjs.onEvent()` synchronously, so it only works when the Prebid instance is already loaded. Bundles whose Prebid global hydrates late (e.g. AtlasMG's `__pmc_atlasmg_pbjs` on PMC / SHE Media) have no safe way to pass an instance: passing a queue-only stub throws, and passing nothing means the caller must re-implement the queue dance. `OptablePrebidAnalytics.hookIntoPrebid` already solves this — `setupAB` should behave the same way.

## What Changed

- `abTestAssignment.ts`: split `setHooks` into `registerHooks` (the previous direct-attach body) + a new `setHooks` that mirrors `hookIntoPrebid` — when `pbjsInstance.onEvent` is not a function, it defers registration onto `pbjsInstance.que`; otherwise it registers immediately. Also no-ops on a falsy instance.

## How to Test

- With a ready Prebid instance: `setupAB({ variants, pbjs })` attaches immediately and stamps `splitTestAssignment` on the next auction (unchanged behavior).
- With a not-yet-loaded instance: `setupAB({ variants, pbjs: { que: [] } })` no longer throws; hook registration runs once `que` is drained by the real Prebid, and bids are stamped from that point.

- [ ] Tested
- [ ] Docs / README updated (if public API changed)

## Notes

- Backwards compatible: the ready-instance path is identical to before; only the not-ready path changes (previously threw / no-op'd).
- Unblocks removing the bundle-side queue workaround in PMC / SHE Media (optable-solutions) — after this ships they can pass `pbjs: getPbjs()` straight into `setupAB` again.

- [ ] Breaking change
- [ ] Requires release
